### PR TITLE
Enhance PR build workflow with artifact handling

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -164,6 +164,7 @@ jobs:
           echo "url=${URL}" >> $GITHUB_OUTPUT
 
       - name: "Upload log (${{ matrix.platform }}"
+        uses: actions/upload-artifact@v4
         id: upload-log-artifact
         if: ${{ steps.files.outputs.lfn != "" }}
         with:


### PR DESCRIPTION
Download artifacts and re-upload them one by one, to have them as separate artifacts.