### PR TITLE
Remove exit command from PR build workflow

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -124,7 +124,6 @@ jobs:
           sudo snap install snapcraft --classic
           # export SNAPCRAFT_STORE_CREDENTIALS="${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}" 
           # snapcraft whoami || true
-          exit 1
           
           mkdir -p ~/.local/share/snapcraft
           echo "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials


### PR DESCRIPTION
Removed exit command to allow workflow to continue.