### PR TITLE
Revert "Fix renovate.json managerFilePatterns to properly match snap/snapcraft.yaml"

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -7,7 +7,7 @@
     {
       "customType": "regex",
       "managerFilePatterns": [
-        "/^snap/snapcraft\\.yaml$/"
+        "^snap/snapcraft\\.yaml$"
       ],
       "matchStrings": [
         "^version: \"?(?<currentValue>[^\"\n]*)\"?$"


### PR DESCRIPTION
Reverts giaever-online-iot/zwave-js-ui#164

It still doesn't recognize the version string in `snapcraft.yaml`