### PR TITLE
chore: gitignore the Snap Store login credential and .claude/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ Session.vim
 *~
 *.snap
 actionlint
+
+# Snap Store credentials — never commit (e.g. `snapcraft export-login` output)
+login
+
+# Claude Code local state (settings, worktrees, logs)
+.claude/


### PR DESCRIPTION
## Summary

Adds two ignore rules to prevent accidental commits:

- **`login`** — the Snap Store macaroon (`snapcraft export-login` output) that lives in the repo root. It's a publish credential and must never be committed. (A recent `git add -A` nearly staged it; this closes that footgun.)
- **`.claude/`** — Claude Code local state, worktrees, and logs.

Docs/config-only; no build or runtime impact.

> If you ever want to track a specific `.claude/` file (e.g. a team `settings.json`), add a negation like `!.claude/settings.json` below the rule.