### PR TITLE
ci: scope build/release triggers to snap/ + src/ (don't build or publish on docs)

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -4,12 +4,13 @@ on:
   pull_request:
     branches: [main]
     types: [opened, synchronize, reopened]
-    paths-ignore:
-      - '.github/**'
-      - '**/*.md'
-      - '**/*.txt'
-      - 'renovate.json'
-      - '.vscode/**'
+    # Only the snap recipe and its bundled source affect the built artifact, so
+    # build + publish to v<MM>/edge/<PR> ONLY when those change. Everything else
+    # (docs, LICENSE, .gitignore, .github/**, renovate.json, editor config) is
+    # intentionally excluded — a doc/config edit must not mint a store revision.
+    paths:
+      - 'snap/**'
+      - 'src/**'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -4,6 +4,12 @@ on:
   pull_request:
     types: [closed]
     branches: [main]
+    # Mirror pr-build-snap's filter: a merge only has something to promote when
+    # the PR built something (snap/ or src/). Docs-only merges skip entirely;
+    # the branch-has-revisions guard remains the runtime backstop.
+    paths:
+      - 'snap/**'
+      - 'src/**'
 
 permissions:
   contents: read


### PR DESCRIPTION
## Summary

A trigger audit found that **docs/config-only changes can kick off a full Launchpad build and publish a snap revision to the store**. This switches both store-touching workflows from a denylist / no-filter to a positive `paths:` allowlist.

The snap's only build inputs are **`snap/`** (the recipe) and **`src/`** (the hooks/helpers bundled into the snap). Nothing else in the repo affects the built artifact, so only those should trigger a build or a promote.

## What changed

- **`pr-build-snap.yml`**: `paths-ignore: [.github, *.md, *.txt, renovate.json, .vscode]` → `paths: [snap/**, src/**]`.
- **`release-on-merge.yml`**: added `paths: [snap/**, src/**]` (it previously had no filter and ran on *every* merge).

## Why

- The old `paths-ignore` denylist **leaked `LICENSE` and `.gitignore`** — editing either ran a build and published a revision to `v<MM>/edge/<PR>`. It was also latent-leaky: any future root config / non-`.md` doc would trigger too.
- `release-on-merge` had **no path filter**, so every docs-only merge spun up a runner just to hit the `branch-has-revisions` guard and no-op (e.g. the merge of #191).
- An allowlist is **self-maintaining**: new docs/config files can never trigger a build or publish. Because each build publishes an immutable store revision, this precision matters more than for test-only CI.

## Trigger matrix (after this change)

| Change | pr-build-snap | release-on-merge |
|---|---|---|
| `snap/snapcraft.yaml` (e.g. Renovate version bump) | ✅ build + publish | ✅ promote on merge |
| `src/**` (hooks/helpers) | ✅ | ✅ |
| docs / `*.md` / `LICENSE` / `.gitignore` / `.github/**` / `renovate.json` / `.vscode/**` | ⛔ skipped | ⛔ skipped |

The `branch-has-revisions` guard in `release-on-merge` stays as the runtime backstop (e.g. a `src/` PR whose build failed merges → guard no-ops).

## Not changed

`block-fork-prs.yml` stays unfiltered **on purpose** — it's a policy gate (target-branch + fork check) that must run on every PR regardless of content.

## Test plan

- [x] `yq` validates both workflows; `paths-ignore` removed from pr-build; the `merged == true` job guard intact in release-on-merge.
- Note: this PR only touches `.github/**`, so under the new allowlist it will not trigger a build (correct — only `block-fork-prs` runs).