### PR TITLE
feat: zwave-js-ui.backup — off-box shipper for ZUI's backups (duplicity)

### DIFF
--- a/.github/workflows/lint-test.yml
+++ b/.github/workflows/lint-test.yml
@@ -22,4 +22,6 @@ jobs:
       - name: Install yq
         run: sudo snap install yq
       - name: Unit tests
-        run: bash tests/logs_test.sh
+        run: |
+          bash tests/logs_test.sh
+          bash tests/backup_test.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -79,7 +79,7 @@ Snap users set config with `snap set zwave-js-ui server.host=0.0.0.0` (namespace
 
 ### User commands (`src/bin/`)
 
-`daemonize`/`de-daemonize`/`restart` wrap `snapctl` service control and require root + connected plugs. `logs` is the unified, terminal-friendly log follower. `backup` ships ZUI's backup directory (`$BACKUPS_DIR`, default `$SNAP_DATA/backups`) off-box via **duplicity** — encrypted (asymmetric GPG), incremental, optional daily timer — and restores it back for ZUI's in-app recovery. It does **not** create backups itself: it requires ZUI's own scheduled backups to be enabled (off by default) and is configured via `snap set zwave-js-ui backup.*` (`backup.target`, `backup.dir`, `backup.encrypt-key`, `backup.schedule`, …). See `docs/superpowers/specs/2026-06-10-backup-design.md`.
+`daemonize`/`de-daemonize`/`restart` wrap `snapctl` service control and require root + connected plugs. `logs` is the unified, terminal-friendly log follower. `backup` ships ZUI's backup directory (`$BACKUPS_DIR`, default `$SNAP_DATA/backups`) off-box via **duplicity** — encrypted (asymmetric GPG), incremental, optional daily timer — and restores it back for ZUI's in-app recovery. It does **not** create backups itself: it requires ZUI's own scheduled backups to be enabled (off by default) and is configured via `snap set zwave-js-ui backup.*` (`backup.target`, `backup.dir`, `backup.encrypt-key`, …). A fixed daily timer runs it once `backup.target` is set. See `docs/superpowers/specs/2026-06-10-backup-design.md`.
 
 ### Paths & layout
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ zwave-js-ui.disable    # de-daemonize
 zwave-js-ui.restart
 zwave-js-ui.exec       # run the app in the foreground (debug boot issues before enabling)
 zwave-js-ui.logs       # unified, terminal-friendly live log view; append zui|zwjs to filter
+zwave-js-ui.backup     # ship ZUI's backups off-box via duplicity (restore|list|status)
 snap logs zwave-js-ui -f                  # manual fallback when "log to file" is OFF (syslog/journal)
 tail -f $SNAP_DATA/*.log                  # manual fallback when "log to file" is ON
 ```
@@ -78,7 +79,7 @@ Snap users set config with `snap set zwave-js-ui server.host=0.0.0.0` (namespace
 
 ### User commands (`src/bin/`)
 
-`daemonize`/`de-daemonize`/`restart` wrap `snapctl` service control and require root + connected plugs. `logs` is the unified, terminal-friendly log follower (the `logs` app: merges the ZUI app + Z-Wave JS driver streams, auto-selecting file vs journal per stream). `backup` is present but minimal/WIP.
+`daemonize`/`de-daemonize`/`restart` wrap `snapctl` service control and require root + connected plugs. `logs` is the unified, terminal-friendly log follower. `backup` ships ZUI's backup directory (`$BACKUPS_DIR`, default `$SNAP_DATA/backups`) off-box via **duplicity** — encrypted (asymmetric GPG), incremental, optional daily timer — and restores it back for ZUI's in-app recovery. It does **not** create backups itself: it requires ZUI's own scheduled backups to be enabled (off by default) and is configured via `snap set zwave-js-ui backup.*` (`backup.target`, `backup.dir`, `backup.encrypt-key`, `backup.schedule`, …). See `docs/superpowers/specs/2026-06-10-backup-design.md`.
 
 ### Paths & layout
 

--- a/docs/superpowers/plans/2026-06-10-backup.md
+++ b/docs/superpowers/plans/2026-06-10-backup.md
@@ -175,8 +175,14 @@ export SNAP="$HERE/fixtures"
 SNAP_DATA="$(mktemp -d)"; export SNAP_DATA
 SNAP_COMMON="$(mktemp -d)"; export SNAP_COMMON
 trap 'rm -rf "$SNAP_DATA" "$SNAP_COMMON"' EXIT
+
+# Test stub for snapctl: `snapctl get backup.foo-bar` reads $SNAPCTL_backup_foo_bar.
+snapctl() { case "$1" in get) local k="${2//[.-]/_}"; eval "printf '%s' \"\${SNAPCTL_${k}:-}\"" ;; *) : ;; esac; }
+
 # shellcheck source=/dev/null
-source "$ROOT/src/bin/backup"
+source "$ROOT/src/bin/backup"          # backup's own helpers (+ stub functions via $SNAP); main is guarded
+# shellcheck source=/dev/null
+source "$ROOT/src/helper/functions"    # REAL shared helpers (e.g. backup_dir), resolved against the snapctl stub above
 
 # --- tests appended by later tasks ---
 
@@ -185,18 +191,7 @@ finish
 
 - [ ] **Step 2: Replace the `src/bin/backup` stub with the skeleton**
 
-Overwrite `src/bin/backup` with the "Script skeleton" from the File structure section; `chmod +x src/bin/backup`.
-
-The fixture stub `tests/fixtures/helper/functions` must provide `snapctl` for tests. Append to `tests/fixtures/helper/functions`:
-```bash
-# Test stub: snapctl get returns from a SNAPCTL_<key> env var; everything else no-op.
-snapctl() {
-    case "$1" in
-        get) local k="${2//[.-]/_}"; eval "printf '%s' \"\${SNAPCTL_${k}:-}\"" ;;
-        *) : ;;
-    esac
-}
-```
+Overwrite `src/bin/backup` with the "Script skeleton" from the File structure section; `chmod +x src/bin/backup`. Do **not** modify `tests/fixtures/helper/functions` (the `snapctl` stub lives in `backup_test.sh`; the shared logs fixture stays untouched).
 
 - [ ] **Step 3: Sanity-run**
 

--- a/docs/superpowers/plans/2026-06-10-backup.md
+++ b/docs/superpowers/plans/2026-06-10-backup.md
@@ -1,0 +1,639 @@
+# `zwave-js-ui.backup` Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add a `zwave-js-ui.backup` command that ships ZUI's existing backup directory (`$BACKUPS_DIR`) off-box via duplicity — encrypted (asymmetric GPG), incremental, optional snapd-timer schedule — and restores it back for ZUI's in-app recovery.
+
+**Architecture:** A single bash command (`src/bin/backup`) decomposed into small pure functions (dir resolution, arg/subcommand parsing, config reads, encryption-flag logic, duplicity-command building) that are unit-tested by the existing zero-dependency bash harness. duplicity + GnuPG + backend libs are staged into the snap; the backup *location* is one config key (`backup.dir` → `BACKUPS_DIR`) shared by ZUI (writer) and `backup` (reader) via a `backup_dir` helper in `functions`. Staging/runtime/GPG/timer feasibility are de-risked by on-device spikes first.
+
+**Tech Stack:** Bash, duplicity (Python; GnuPG), `snapctl`, snapcraft `core24`. Tests: the existing `tests/` bash harness + `shellcheck`.
+
+**Source spec:** `docs/superpowers/specs/2026-06-10-backup-design.md` (read it first).
+
+---
+
+## File structure
+
+| File | Responsibility |
+|------|----------------|
+| `src/bin/backup` (replace stub) | The command: pure helpers + `main` dispatch (`backup` / `restore` / `list` / `status`). Runs `main` only when executed, not when sourced (enables unit tests). |
+| `src/helper/functions` (modify) | Add the shared `backup_dir` helper (single source of truth for the location). |
+| `src/helper/env-wrapper` (modify) | Export `BACKUPS_DIR="$(backup_dir)"` so ZUI writes where `backup` reads. |
+| `src/hooks/configure` (modify) | Validate `backup.dir` is absolute when set. |
+| `snap/snapcraft.yaml` (modify) | `backup` app + a `backup-timer` scheduled daemon; `stage-packages` duplicity + GnuPG + backends; plugs (`network`, `home`, `removable-media`, `gpg-public-keys`, `gpg-keys`). |
+| `tests/backup_test.sh` (new) | Unit tests for the pure helpers (sourced via the same stub harness as `logs_test.sh`). |
+| `CLAUDE.md` (modify) | Document `zwave-js-ui.backup`, the `backup.*` config, and the ZUI-backups dependency. |
+
+**Script skeleton** (`src/bin/backup` — every later task adds functions in the marked section; `main` runs only when executed so the harness can source it):
+
+```bash
+#!/usr/bin/env bash
+# backup — ship ZUI's backup directory off-box via duplicity
+: "${SNAP:?SNAP must be set}"
+source "$SNAP/helper/functions"
+
+ARCHIVE_DIR="${SNAP_COMMON:-/tmp}/duplicity-cache"
+
+# ---- pure helpers (unit-tested) added by later tasks ----
+
+main() {
+    : # assembled in Task 10
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi
+```
+
+---
+
+## Task 1 (SPIKE): Stage duplicity + backends and confirm it runs under confinement
+
+Resolves VERIFY #1. Needs a snap build + install (maintainer with `sudo`). Outcome may adjust later tasks' package list / binary path.
+
+**Files:** `snap/snapcraft.yaml` (temporary spike edit).
+
+- [ ] **Step 1: Add duplicity to a throwaway `backup-deps` part**
+
+In `snap/snapcraft.yaml`, add under `parts:`:
+```yaml
+  backup-deps:
+    plugin: nil
+    stage-packages:
+      - duplicity
+      - gnupg
+      - python3-boto3      # s3
+      - python3-b2sdk      # b2
+      - python3-paramiko   # sftp/scp
+      - python3-requests   # webdav and others
+```
+
+- [ ] **Step 2: Build and install**
+
+Run:
+```bash
+snapcraft clean && snapcraft
+sudo snap install --dangerous ./zwave-js-ui_*_amd64.snap
+```
+Expected: builds and installs without unresolved-dependency errors.
+
+- [ ] **Step 3: Confirm duplicity runs inside confinement and can do a local backup/restore**
+
+Run (uses the existing `exec`-style confinement — temporarily expose a shell, or add a throwaway app `duptest: { command: usr/bin/duplicity }`):
+```bash
+sudo zwave-js-ui.duptest --version          # expect: "duplicity x.y.z"
+# minimal local round-trip inside $SNAP_COMMON (always writable):
+# (do this via a temporary app or `snap run --shell`)
+mkdir -p $SNAP_COMMON/spike/src $SNAP_COMMON/spike/dst; echo hi > $SNAP_COMMON/spike/src/a
+duplicity --no-encryption --archive-dir $SNAP_COMMON/dup-cache $SNAP_COMMON/spike/src file://$SNAP_COMMON/spike/bak
+duplicity --no-encryption --archive-dir $SNAP_COMMON/dup-cache file://$SNAP_COMMON/spike/bak $SNAP_COMMON/spike/dst
+cat $SNAP_COMMON/spike/dst/a       # expect: hi
+```
+Expected: backup + restore succeed unencrypted to a local `file://` target.
+
+- [ ] **Step 4: Record findings; revert the spike**
+
+Note the working binary path (`/usr/bin/duplicity` vs `lib/.../bin`), the actual package names that resolved on core24, and any backend that failed to stage. Update this plan's Task 11 package list to match. `git checkout snap/snapcraft.yaml` to drop the throwaway part/app (the real wiring is Task 11). **No commit** (spike only).
+
+> If duplicity cannot run under strict confinement at all, STOP and escalate — the design needs rework before proceeding.
+
+---
+
+## Task 2 (SPIKE): GPG asymmetric encrypt (backup) + decrypt (restore) in confinement
+
+Resolves VERIFY #2. Decides the keyring mechanics. Needs the Task 1 build. Outcome fixes the `GNUPGHOME`/keyring approach used in Tasks 8/10.
+
+**Files:** none (spike).
+
+- [ ] **Step 1: Decide and test the backup-time keyring (public key, no interface)**
+
+Approach to validate: a **snap-local keyring** in `$SNAP_COMMON/.gnupg` holding only the user's *public* key (imported once), so backup needs no gpg interface.
+```bash
+export GNUPGHOME=$SNAP_COMMON/.gnupg; mkdir -p "$GNUPGHOME"; chmod 700 "$GNUPGHOME"
+gpg --import < your-public-key.asc           # one-time import (later: a `backup import-key` subcommand or doc step)
+duplicity --encrypt-key <FPR> --archive-dir $SNAP_COMMON/dup-cache $SNAP_COMMON/spike/src file://$SNAP_COMMON/spike/bak2
+```
+Expected: encrypted backup succeeds non-interactively (public-key encryption needs no passphrase).
+
+- [ ] **Step 2: Test restore-time decrypt via the user's private key (`gpg-keys`)**
+
+Connect and test:
+```bash
+sudo snap connect zwave-js-ui:gpg-keys
+# restore must reach the user's secret key + agent (interactive passphrase):
+GNUPGHOME=<user ~/.gnupg path the interface exposes> \
+  duplicity restore --encrypt-key <FPR> --archive-dir $SNAP_COMMON/dup-cache file://$SNAP_COMMON/spike/bak2 $SNAP_COMMON/spike/dst2
+```
+Expected: prompts for the key passphrase, then restores. **Record** the exact `GNUPGHOME` the `gpg-keys` interface exposes and whether the command must run as the invoking user vs root.
+
+- [ ] **Step 3: Record the decision**
+
+Write the chosen mechanics into the spec's §"Verification items" #2 (resolved): backup keyring location, how the pubkey is imported (a `backup import-key` subcommand vs documented `gpg --import`), and the restore `GNUPGHOME`/user model. Commit that spec update:
+```bash
+git add docs/superpowers/specs/2026-06-10-backup-design.md
+git commit -m "docs(spec): resolve backup GPG keyring mechanics (VERIFY #2)"
+```
+
+> If asymmetric decrypt can't work under confinement, fall back per spec (document manual off-snap decrypt) and escalate.
+
+---
+
+## Task 3 (SPIKE): snapd timer mechanism for a configurable schedule
+
+Resolves VERIFY #3. Research + tiny spike. Decides how `backup.schedule` drives a `timer:`.
+
+- [ ] **Step 1: Confirm the mechanism**
+
+snapd `timer:` is declared statically in `snapcraft.yaml` on a `daemon: oneshot` app; it cannot be rewritten at runtime. Decide the model: a **fixed daily timer** on a `backup-timer` oneshot app that simply runs `backup`, which **no-ops unless `backup.target` and `backup.schedule` are set** (i.e. `backup.schedule` acts as an on/off gate the script checks, not the literal cron). Confirm by reading snapcraft `timer` docs (WebFetch `https://snapcraft.io/docs/timer-string-format`).
+
+- [ ] **Step 2: Record the decision**
+
+Document in the spec §"Verification items" #3 (resolved): a static `timer:` (e.g. `00:00`) on `backup-timer`; the script exits early unless enabled; finer schedules are out of scope (daily is enough for daily-incremental). Commit the spec update.
+
+```bash
+git add docs/superpowers/specs/2026-06-10-backup-design.md
+git commit -m "docs(spec): resolve snapd timer model for backup schedule (VERIFY #3)"
+```
+
+---
+
+## Task 4: Test harness entry + `backup` skeleton
+
+**Files:** Create `tests/backup_test.sh`; replace `src/bin/backup` stub with the skeleton.
+
+- [ ] **Step 1: Create the test runner**
+
+`tests/backup_test.sh` (mirrors `tests/logs_test.sh`):
+```bash
+#!/usr/bin/env bash
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+source "$HERE/lib/assert.sh"
+
+export SNAP="$HERE/fixtures"
+SNAP_DATA="$(mktemp -d)"; export SNAP_DATA
+SNAP_COMMON="$(mktemp -d)"; export SNAP_COMMON
+trap 'rm -rf "$SNAP_DATA" "$SNAP_COMMON"' EXIT
+# shellcheck source=/dev/null
+source "$ROOT/src/bin/backup"
+
+# --- tests appended by later tasks ---
+
+finish
+```
+
+- [ ] **Step 2: Replace the `src/bin/backup` stub with the skeleton**
+
+Overwrite `src/bin/backup` with the "Script skeleton" from the File structure section; `chmod +x src/bin/backup`.
+
+The fixture stub `tests/fixtures/helper/functions` must provide `snapctl` for tests. Append to `tests/fixtures/helper/functions`:
+```bash
+# Test stub: snapctl get returns from a SNAPCTL_<key> env var; everything else no-op.
+snapctl() {
+    case "$1" in
+        get) local k="${2//[.-]/_}"; eval "printf '%s' \"\${SNAPCTL_${k}:-}\"" ;;
+        *) : ;;
+    esac
+}
+```
+
+- [ ] **Step 3: Sanity-run**
+
+Run: `bash tests/backup_test.sh`
+Expected: `0 passed, 0 failed`, exit 0 (sources cleanly, `main` does not run).
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add tests/backup_test.sh src/bin/backup tests/fixtures/helper/functions
+git commit -m "test: backup harness + skeleton + snapctl stub"
+```
+
+---
+
+## Task 5: `backup_dir` helper (shared) + env-wrapper mapping
+
+**Files:** Modify `src/helper/functions`, `src/helper/env-wrapper`, `tests/backup_test.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `tests/backup_test.sh` before `finish`:
+```bash
+# default when unset
+assert_eq "$(backup_dir)" "$SNAP_DATA/backups" "default backup dir"
+# honors backup.dir when set
+SNAPCTL_backup_dir="/srv/zui-backups" assert_eq "$(backup_dir)" "/srv/zui-backups" "configured backup dir"
+```
+
+- [ ] **Step 2: Run, verify failure**
+
+Run: `bash tests/backup_test.sh` → fails (`backup_dir` undefined).
+
+- [ ] **Step 3: Implement in `functions`**
+
+Add to `src/helper/functions` (after `test_default_config`, top-level):
+```bash
+function backup_dir {
+    local d; d=$(snapctl get backup.dir 2>/dev/null)
+    echo "${d:-$SNAP_DATA/backups}"
+}
+```
+
+- [ ] **Step 4: Wire env-wrapper**
+
+In `src/helper/env-wrapper`, after the existing `ZWAVEJS_LOGS_DIR` export, add:
+```bash
+BACKUPS_DIR="$(backup_dir)"; export BACKUPS_DIR
+```
+
+- [ ] **Step 5: Run, verify pass**
+
+Run: `bash tests/backup_test.sh` → all pass. Also `bash -n src/helper/env-wrapper`.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add src/helper/functions src/helper/env-wrapper tests/backup_test.sh
+git commit -m "feat(backup): backup_dir helper shared by env-wrapper and backup"
+```
+
+---
+
+## Task 6: Argument parsing / subcommand dispatch
+
+**Files:** Modify `src/bin/backup`, `tests/backup_test.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append before `finish`:
+```bash
+assert_eq "$(parse_sub '')"        "backup"  "no arg -> backup"
+assert_eq "$(parse_sub 'restore')" "restore" "restore"
+assert_eq "$(parse_sub 'list')"    "list"    "list"
+assert_eq "$(parse_sub 'status')"  "status"  "status"
+parse_sub bogus >/dev/null 2>&1; assert_status "$?" "2" "unknown -> 2"
+```
+
+- [ ] **Step 2: Run, verify failure.** `bash tests/backup_test.sh` → fails.
+
+- [ ] **Step 3: Implement** (in `src/bin/backup` pure-helpers section):
+```bash
+usage() {
+    cat <<EOF
+Usage: ${SNAP_NAME}.backup [restore [<time>] | list | status]
+
+  (no arg)   ship ZUI's backups now (incremental; full if older than threshold)
+  restore    fetch+decrypt the latest backup back into the backup dir
+  list       show available backup sets
+  status     show config + last run
+  -h|--help  this help
+EOF
+}
+
+parse_sub() {                  # $1 subcommand token -> backup|restore|list|status; status 2 if unknown
+    case "${1:-}" in
+        ""|backup) echo backup ;;
+        restore)   echo restore ;;
+        list)      echo list ;;
+        status)    echo status ;;
+        *)         return 2 ;;
+    esac
+}
+```
+
+- [ ] **Step 4: Run, verify pass.** `bash tests/backup_test.sh` → all pass.
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/bin/backup tests/backup_test.sh
+git commit -m "feat(backup): subcommand parsing"
+```
+
+---
+
+## Task 7: Config reads + encryption-flag logic
+
+**Files:** Modify `src/bin/backup`, `tests/backup_test.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append before `finish`:
+```bash
+# encryption_args: encrypt-key set -> --encrypt-key; encrypt=false -> --no-encryption; neither -> status 2
+assert_eq "$(SNAPCTL_backup_encrypt_key=ABC123 encryption_args)" "--encrypt-key ABC123" "enc key"
+assert_eq "$(SNAPCTL_backup_encrypt=false encryption_args)"      "--no-encryption"       "no-encryption opt-out"
+encryption_args >/dev/null 2>&1; assert_status "$?" "2" "neither -> refuse"
+# target
+assert_eq "$(SNAPCTL_backup_target=file:///b cfg target)" "file:///b" "cfg reads target"
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+- [ ] **Step 3: Implement:**
+```bash
+cfg() { snapctl get "backup.$1" 2>/dev/null; }    # $1 = key suffix, e.g. target, encrypt-key
+
+encryption_args() {            # echoes "--encrypt-key X" or "--no-encryption"; status 2 if neither
+    local key; key=$(cfg encrypt-key)
+    if [ -n "$key" ]; then
+        echo "--encrypt-key $key"
+    elif [ "$(cfg encrypt)" = false ]; then
+        echo "--no-encryption"
+    else
+        return 2
+    fi
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/bin/backup tests/backup_test.sh
+git commit -m "feat(backup): config reads and encryption-flag logic"
+```
+
+---
+
+## Task 8: duplicity command builders
+
+**Files:** Modify `src/bin/backup`, `tests/backup_test.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append before `finish`:
+```bash
+SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target='file:///tgt' SNAPCTL_backup_full_if_older_than=7D
+export SNAPCTL_backup_encrypt_key SNAPCTL_backup_target SNAPCTL_backup_full_if_older_than
+src="$SNAP_DATA/backups"
+b="$(build_backup_cmd "$src")"
+assert_contains "$b" "duplicity"              "backup uses duplicity"
+assert_contains "$b" "--encrypt-key KEY"      "backup enc key"
+assert_contains "$b" "--full-if-older-than 7D" "backup full-if-older"
+assert_contains "$b" "--archive-dir"          "backup archive-dir"
+assert_contains "$b" "file:///tgt"            "backup target"
+r="$(build_restore_cmd "$SNAP_DATA/restore")"
+assert_contains "$r" "duplicity restore"      "restore verb"
+assert_contains "$r" "file:///tgt"            "restore target"
+l="$(build_list_cmd)"
+assert_contains "$l" "collection-status"      "list verb"
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+- [ ] **Step 3: Implement:**
+```bash
+full_if_older() { local v; v=$(cfg full-if-older-than); echo "${v:-7D}"; }
+
+build_backup_cmd() {           # $1 source dir -> duplicity backup command string
+    printf 'duplicity %s --full-if-older-than %s --archive-dir %q %q %q' \
+        "$(encryption_args)" "$(full_if_older)" "$ARCHIVE_DIR" "$1" "$(cfg target)"
+}
+
+build_restore_cmd() {          # $1 dest dir [$2 time] -> duplicity restore command string
+    local timearg=""; [ -n "${2:-}" ] && timearg="--time ${2}"
+    printf 'duplicity restore %s %s --archive-dir %q %q %q' \
+        "$timearg" "$(encryption_args)" "$ARCHIVE_DIR" "$(cfg target)" "$1"
+}
+
+build_list_cmd() {             # -> duplicity collection-status command string
+    printf 'duplicity collection-status --archive-dir %q %q' "$ARCHIVE_DIR" "$(cfg target)"
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/bin/backup tests/backup_test.sh
+git commit -m "feat(backup): duplicity command builders (backup/restore/list)"
+```
+
+---
+
+## Task 9: `has_backups` (empty-source no-op)
+
+**Files:** Modify `src/bin/backup`, `tests/backup_test.sh`.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append before `finish`:
+```bash
+mkdir -p "$SNAP_DATA/backups"
+has_backups && echo bad; assert_status "$?" "1" "empty dir -> no backups"   # empty
+: > "$SNAP_DATA/backups/x"; has_backups; assert_status "$?" "0" "non-empty -> has backups"
+rm -rf "$SNAP_DATA/backups"; has_backups; assert_status "$?" "1" "absent -> no backups"
+```
+
+- [ ] **Step 2: Run, verify failure.**
+
+- [ ] **Step 3: Implement:**
+```bash
+has_backups() {                # status 0 if backup_dir exists and is non-empty
+    local d; d="$(backup_dir)"
+    [ -d "$d" ] && [ -n "$(ls -A "$d" 2>/dev/null)" ]
+}
+```
+
+- [ ] **Step 4: Run, verify pass.**
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/bin/backup tests/backup_test.sh
+git commit -m "feat(backup): has_backups source check"
+```
+
+---
+
+## Task 10: Assemble `main`
+
+**Files:** Modify `src/bin/backup`. No unit test (orchestration; covered by Task 14 integration). Verify with `shellcheck` + dry paths.
+
+- [ ] **Step 1: Implement `main`** (replace the placeholder):
+```bash
+main() {
+    case "${1:-}" in -h|--help) usage; exit 0 ;; esac
+    require_root
+
+    local sub; sub="$(parse_sub "${1:-}")" || { usage >&2; exit 2; }
+    mkdir -p "$ARCHIVE_DIR"
+    export GNUPGHOME="${SNAP_COMMON}/.gnupg"   # snap-local keyring (per Task 2 decision)
+
+    local target; target="$(cfg target)"
+    case "$sub" in
+        backup)
+            if [ -z "$target" ]; then
+                lprint "Backup not configured: set 'snap set ${SNAP_NAME} backup.target=<duplicity-url>'." >&2; exit 1
+            fi
+            if ! has_backups; then
+                lprint "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings." ; exit 0
+            fi
+            local enc; enc="$(encryption_args)" || {
+                lprint "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'." >&2; exit 1; }
+            eval "$(build_backup_cmd "$(backup_dir)")"
+            # prune old chains
+            local keep; keep="$(cfg retention)"; keep="${keep:-3}"
+            duplicity remove-all-but-n-full "$keep" --force --archive-dir "$ARCHIVE_DIR" "$target" || true
+            ;;
+        restore)
+            [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
+            local dest; dest="$(backup_dir)"; mkdir -p "$dest"
+            lprint "Restoring into ${dest}; you'll be prompted for your GPG key passphrase." >&2
+            eval "$(build_restore_cmd "$dest" "${2:-}")"
+            lprint "Done. Now use ZUI's in-app restore (NVM / store) to recover." >&2
+            ;;
+        list)   eval "$(build_list_cmd)" ;;
+        status) lprint "target=$(cfg target) dir=$(backup_dir) encrypt-key=$(cfg encrypt-key)" ;;
+    esac
+}
+```
+
+- [ ] **Step 2: Lint.** `shellcheck --severity=warning src/bin/backup` → clean (add `# shellcheck disable=SC2294` above the `eval` lines if flagged).
+
+- [ ] **Step 3: Dry checks (no runtime needed).**
+```bash
+SNAP="$PWD/tests/fixtures" SNAP_DATA="$(mktemp -d)" SNAP_COMMON="$(mktemp -d)" bash src/bin/backup --help; echo "rc=$?"   # usage, rc=0
+SNAP="$PWD/tests/fixtures" SNAP_DATA="$(mktemp -d)" SNAP_COMMON="$(mktemp -d)" bash src/bin/backup; echo "rc=$?"          # "Backup not configured", rc=1
+```
+
+- [ ] **Step 4: Re-run unit suite** (`bash tests/backup_test.sh` still green; sourcing must not run `main`).
+
+- [ ] **Step 5: Commit**
+```bash
+git add src/bin/backup
+git commit -m "feat(backup): assemble main (backup/restore/list/status dispatch)"
+```
+
+---
+
+## Task 11: Wire into the snap (`snapcraft.yaml`)
+
+**Files:** Modify `snap/snapcraft.yaml`. Use the package list / binary path confirmed in Task 1.
+
+- [ ] **Step 1: Add the staged deps** under `parts:` (adjust names per Task 1 findings):
+```yaml
+  backup-deps:
+    plugin: nil
+    stage-packages:
+      - duplicity
+      - gnupg
+      - python3-boto3
+      - python3-b2sdk
+      - python3-paramiko
+      - python3-requests
+```
+
+- [ ] **Step 2: Add the `backup` app and scheduled timer** under `apps:`:
+```yaml
+  backup:
+    command: bin/backup
+    plugs:
+      - network
+      - home
+      - removable-media
+      - gpg-public-keys
+      - gpg-keys
+  backup-timer:
+    command: bin/backup
+    daemon: oneshot
+    timer: "00:00"
+    plugs:
+      - network
+      - home
+      - removable-media
+      - gpg-public-keys
+```
+
+- [ ] **Step 3: Validate YAML** — `yq '.apps.backup, .apps."backup-timer", .parts."backup-deps"' snap/snapcraft.yaml`.
+
+- [ ] **Step 4: Commit**
+```bash
+git add snap/snapcraft.yaml
+git commit -m "feat(backup): stage duplicity + add backup app and daily timer"
+```
+
+---
+
+## Task 12: `configure` validates `backup.dir`
+
+**Files:** Modify `src/hooks/configure`.
+
+- [ ] **Step 1: Add validation** after the existing checks, before `test_default_config`:
+```bash
+BACKUP_DIR_CFG=$(snapctl get backup.dir)
+if [ -n "${BACKUP_DIR_CFG}" ] && [[ "${BACKUP_DIR_CFG}" != /* ]]; then
+    echo "!! backup.dir must be an absolute path, got ${BACKUP_DIR_CFG}" >&2
+    exit 1
+fi
+```
+
+- [ ] **Step 2: Lint + syntax.** `shellcheck --severity=warning src/hooks/configure` and `bash -n src/hooks/configure`.
+
+- [ ] **Step 3: Commit**
+```bash
+git add src/hooks/configure
+git commit -m "feat(backup): validate backup.dir is absolute in configure"
+```
+
+---
+
+## Task 13: Docs (`CLAUDE.md` + in-command help)
+
+**Files:** Modify `CLAUDE.md`.
+
+- [ ] **Step 1:** In the command list, add:
+```
+zwave-js-ui.backup     # ship ZUI's backups off-box via duplicity (restore|list|status)
+```
+- [ ] **Step 2:** Update the "User commands (`src/bin/`)" paragraph: `backup` now ships ZUI's backup dir off-box (duplicity, encrypted, incremental); note it requires ZUI's own scheduled backups to be enabled (off by default) and is configured via `snap set zwave-js-ui backup.*`.
+- [ ] **Step 3: Commit**
+```bash
+git add CLAUDE.md
+git commit -m "docs(backup): document zwave-js-ui.backup and backup.* config"
+```
+
+---
+
+## Task 14: On-device end-to-end integration
+
+**Files:** none (validation). Needs maintainer + `sudo`. Confirms the spikes' decisions hold in the real wiring.
+
+- [ ] **Step 1: Build + install + connect**
+```bash
+snapcraft clean && snapcraft
+sudo snap install --dangerous ./zwave-js-ui_*_amd64.snap
+sudo snap connect zwave-js-ui:gpg-public-keys
+sudo snap connect zwave-js-ui:gpg-keys
+```
+
+- [ ] **Step 2: Configure a local target + key; import pubkey**
+```bash
+sudo snap set zwave-js-ui backup.target="file:///var/snap/zwave-js-ui/common/test-target"
+sudo snap set zwave-js-ui backup.encrypt-key="<your-gpg-fpr>"
+# import the public key into the snap keyring per Task 2 decision
+```
+
+- [ ] **Step 3: Exercise the flows**
+- Empty source: with ZUI backups not yet present → `sudo zwave-js-ui.backup` prints "Nothing to back up", rc 0.
+- Enable ZUI's store+NVM backups in the UI (or drop a dummy file in the backup dir), then `sudo zwave-js-ui.backup` → an encrypted set appears at the target.
+- `sudo zwave-js-ui.backup list` → shows the set.
+- `sudo zwave-js-ui.backup restore` → prompts for GPG passphrase, restores files into the backup dir.
+- Timer: `snap services zwave-js-ui` shows `backup-timer`; it no-ops when unconfigured.
+- `snap get zwave-js-ui backup` reveals only target + fingerprint (no secret).
+
+- [ ] **Step 4: Fix forward any discrepancies; open the PR**
+```bash
+git push -u origin feat/backup
+gh pr create --base main --title "feat: zwave-js-ui.backup (off-box shipper for ZUI backups)" \
+  --body "Implements docs/superpowers/specs/2026-06-10-backup-design.md"
+```
+
+---
+
+## Self-review
+
+- **Spec coverage:** off-box shipping (T8/T10), `backup.dir`→`BACKUPS_DIR` shared helper (T5), whole-dir source + empty no-op (T9/T10), asymmetric encryption + opt-out + refuse (T7/T10), duplicity staging (T1/T11), incremental + full-if-older + prune (T8/T10), commands backup/restore/list/status (T6/T10), config namespace (T7), interfaces + timer (T11), configure validation (T12), restore→ZUI flow (T10), docs (T13), verification items (T1–T3, T14). Covered.
+- **Placeholder scan:** none; spikes (T1–T3) are explicit verify-and-record tasks, not deferred code.
+- **Type/name consistency:** helper names used in `main` (T10) — `parse_sub`, `cfg`, `encryption_args`, `full_if_older`, `build_backup_cmd`, `build_restore_cmd`, `build_list_cmd`, `has_backups`, `backup_dir` — all defined in T5–T9. `ARCHIVE_DIR`/`GNUPGHOME` consistent. `backup.*` keys consistent between T7/T8/T12 and the spec.
+- **Risk note:** T1–T3 outcomes may adjust T8/T10/T11 specifics (binary path, `GNUPGHOME` model, package names); the controller should fold spike findings into those tasks before executing them (as was done for the logs feature).

--- a/docs/superpowers/specs/2026-06-10-backup-design.md
+++ b/docs/superpowers/specs/2026-06-10-backup-design.md
@@ -74,7 +74,7 @@ A single `backup` app (root-required: it reads root-owned `$SNAP_DATA` and write
 zwave-js-ui.backup                 # ship $BACKUPS_DIR now (incremental; full if older than threshold)
 zwave-js-ui.backup restore [<time>]# fetch+decrypt latest (or at <time>) back into $BACKUPS_DIR
 zwave-js-ui.backup list            # duplicity collection-status (available backup sets)
-zwave-js-ui.backup status          # config + last-run summary
+zwave-js-ui.backup status          # show current backup config
 zwave-js-ui.backup --help
 ```
 
@@ -91,7 +91,6 @@ Namespace `backup.*` (snapd config — distinct from ZUI's `settings.json` `back
 | `backup.target` | duplicity target URL (`file://`, `scp://`, `sftp://`, `s3://`, `b2://`, `webdav://`, …). Empty = backup disabled. | (unset) |
 | `backup.encrypt-key` | GPG public-key fingerprint to encrypt to (non-secret) | (unset) |
 | `backup.encrypt` | `false` to disable encryption (plaintext, warns) | `true` |
-| `backup.schedule` | snapd timer spec (e.g. `00:00`, `mon,03:00`); enables the timer | (unset = off) |
 | `backup.full-if-older-than` | force a new full chain after this age | `7D` |
 | `backup.retention` | prune: keep this many full chains (`remove-all-but-n-full`) | `3` |
 | backend creds | e.g. `backup.aws-access-key`, `backup.aws-secret-key`, `backup.b2-*` → mapped to duplicity's env vars | (unset) |
@@ -103,7 +102,7 @@ Namespace `backup.*` (snapd config — distinct from ZUI's `settings.json` `back
 - **Plugs** on the `backup` app: `network` (remote backends), `home` + `removable-media` (`file://` to user dirs / USB), `gpg-public-keys` (encrypt at backup time), `gpg-keys` (decrypt at restore time). `network` is already declared; the gpg interfaces are not auto-connect and need `snap connect` (documented).
 - **`stage-packages`:** `duplicity`, `gnupg`, and the commonly-used backend libs (ssh/paramiko, `python3-boto3` for s3, `b2sdk` for b2, webdav). Exotic backends (Dropbox/gdocs/Azure) documented as addable later, not staged.
 - **`BACKUPS_DIR`** is set *dynamically* from `backup.dir` (via the shared `backup_dir` helper), **not** a static `environment:` entry — `env-wrapper` exports it for the `zwave-js-ui`/`exec` apps, and `bin/backup` resolves the same helper for its source. (Static `environment:` can't read `snapctl`.)
-- **Timer app** for the optional schedule (a `daemon: oneshot` + `timer:` entry), gated on `backup.schedule`.
+- **Timer app** `backup-timer` — a `daemon: oneshot` with a fixed daily `timer: "00:00"` running `bin/backup`. It is **gated in-script on `backup.target`**: unconfigured runs exit 0 quietly (`DAEMONIZED=1`). There is no configurable schedule in this version; the cadence is daily-incremental + weekly-full (via `--full-if-older-than`). A configurable `backup.schedule` is a possible future enhancement.
 
 ## Restore flow
 
@@ -129,7 +128,7 @@ This keeps the fiddly, app-specific recovery in ZUI (its supported path) and lim
 
 1. **duplicity on core24 via `stage-packages`** — confirm the package set (duplicity + GnuPG + backend libs) stages and runs under confinement; confirm the binary path and that `--archive-dir`/`GNUPGHOME`/`HOME` are pointed at writable snap dirs.
 2. **GPG keyring mechanics under confinement** — where the public key lives at backup time (snap-local keyring in `$SNAP_COMMON/.gnupg` that the user imports into, vs `gpg-public-keys` reading `~/.gnupg`), and how restore reaches the user's private key via `gpg-keys` as root vs the invoking user. Pick the simplest that works; document the import/connect steps.
-3. **snapd `timer:` syntax** for `backup.schedule`, and how the timer app maps a `snap set` value to the timer (timers are declared in `snapcraft.yaml`, so a configurable schedule likely means the `configure` hook toggles/uses `snapctl` rather than rewriting YAML — confirm the mechanism).
+3. **RESOLVED — timer model:** a static `timer: "00:00"` on a `daemon: oneshot` `backup-timer` app runs `bin/backup` daily; the script no-ops (exit 0, `DAEMONIZED=1`) until `backup.target` is configured. No configurable `backup.schedule` in this version (descoped); cadence is daily-incremental / weekly-full.
 4. **`gpg-keys`/`gpg-public-keys` auto-connect** — whether to request store auto-connect or document manual `snap connect`.
 
 ## Out of scope (YAGNI)

--- a/docs/superpowers/specs/2026-06-10-backup-design.md
+++ b/docs/superpowers/specs/2026-06-10-backup-design.md
@@ -1,0 +1,141 @@
+# Design: `zwave-js-ui.backup` — encrypted off-box shipper for ZUI's backups
+
+**Date:** 2026-06-10
+**Status:** Approved (pending spec review)
+**Scope:** Snap packaging only (`src/`, `snap/snapcraft.yaml`). No upstream `zwave-js-ui` code is modified; upstream is consulted read-only.
+
+## Problem & purpose
+
+ZUI can create local backups (NVM + store), but they land **inside `$SNAP_DATA`**, which is wiped on `snap remove` and is exactly what you lose in a rebuild/disaster. ZUI does not ship them off-box.
+
+This feature adds **`zwave-js-ui.backup`**: a single-responsibility tool that **moves ZUI's existing backups safely off-box** — encrypted, incremental, to a configurable remote — and restores them back for ZUI to recover from. Disaster recovery that survives `snap remove`.
+
+## Philosophy — single responsibility
+
+**We relocate; ZUI creates.** This tool does **not** create Z-Wave backups, read live data, manage or enable ZUI's backup settings, or touch the running app. It ships whatever ZUI has already written to its backup directory. If ZUI's scheduled backups aren't enabled, there is simply nothing to ship — and that is fine, not an error.
+
+Consequences of this boundary:
+- **No consistency problem.** The artifacts under the backup dir are finalized, closed files ZUI wrote atomically on its own schedule. duplicity reading them is always consistent.
+- **No service stop, ever.** We never read live data, so the Z-Wave network is never interrupted.
+- **No coupling to ZUI's internals.** We back up the backup *directory tree as-is*; we don't parse filenames or subdirs.
+
+## Source of truth — `backup.dir` → `BACKUPS_DIR`
+
+ZUI's backup directory is set only via the `BACKUPS_DIR` env var (default `$STORE_DIR/backups`); there is no UI/`settings.json` key for the path. (Confirmed upstream: `api/config/app.ts` — `backupsDir = process.env.BACKUPS_DIR || joinPath(storeDir, 'backups')`.)
+
+The snap exposes this as **one config key driving both sides**:
+
+- `snap set zwave-js-ui backup.dir=<path>` is the single source of truth for the backup location.
+- `env-wrapper` maps it to `BACKUPS_DIR` for the `zwave-js-ui`/`exec` apps, so **ZUI (writer)** stores backups there.
+- The `backup` command reads the **same** resolved value as its **source**, so **the shipper (reader)** stays in lockstep with the writer.
+
+Resolution lives in **one shared helper** in `functions` (e.g. `backup_dir`): use `snapctl get backup.dir`, falling back to **`$SNAP_DATA/backups`** computed at runtime when unset. Both `env-wrapper` (to export `BACKUPS_DIR`) and `bin/backup` (for its source) call this helper — single source of truth in code, not just in config.
+
+Notes:
+- Computing the default at **runtime** (not seeding a literal) keeps it correct across refreshes, where `$SNAP_DATA`'s revision component changes.
+- Default (`backup.dir` unset) resolves under `$SNAP_DATA` — always writable, no extra interface.
+- A `backup.dir` **outside** `$SNAP_DATA` (e.g. a `home`/removable path) requires the matching interface connected for **both** ZUI and `backup`; ZUI runs as root, so destination ownership/permissions must allow it. Avoid revision-embedded paths (`…/x2/…`) — they go stale on refresh.
+- `configure` validates `backup.dir` (when set) is an absolute path; an unusable value is rejected with a message.
+
+## Scope
+
+**Back up the entire `$BACKUPS_DIR` tree, as-is** — no globbing, no per-file/subdir logic. Whatever ZUI puts there (today `nvm/NVM_*.bin` + `store/store-backup_*.zip`; tomorrow whatever) is shipped. New backup types are included automatically.
+
+For reference (not relied upon by the code), ZUI currently writes:
+- `nvm/NVM_<ts>.bin` — raw controller NVM (the one DR artifact a headless tool can't produce itself; ZUI exports it via the running driver).
+- `store/store-backup_<ts>.zip` — a complete, consistent store snapshot **including `settings.json`** (S0/S2 security keys), `scenes/nodes/users/configurationTemplates.json`, and all top-level `*.jsonl` value/node DBs. (Confirmed: `jsonStore.backup()` + `api/config/store.ts`.)
+
+**Empty/absent `$BACKUPS_DIR`** → clean no-op: print a one-line "nothing to back up (ZUI backups not enabled or none yet)" and exit 0. duplicity is never invoked against a missing/empty source. Not a warning, not a prompt to enable anything.
+
+## Engine — duplicity
+
+duplicity provides encrypted, incremental backups to many backends. It is **not in the snap today** and is added via `stage-packages` (duplicity + GnuPG + per-backend libraries; core24/Ubuntu 24.04).
+
+- **Incremental chains** with periodic fulls (`--full-if-older-than`, default `7D`) and pruning (`remove-older-than`, retention configurable).
+- **Archive/cache dir** must be stable across runs for incrementals → `--archive-dir "$SNAP_COMMON/duplicity-cache"` (revision-independent, writable).
+- The backup **source** is `$BACKUPS_DIR`; the **target** is `backup.target` (a duplicity URL).
+
+## Encryption — asymmetric (no secret in snap config)
+
+Backups are encrypted with **GPG public-key (asymmetric)** encryption, chosen specifically so **no decryption secret is ever stored in snapd config** (where any root user could read it via `snap get`):
+
+- **Backup (encrypt):** `duplicity --encrypt-key <FPR>` to the configured public key. Non-interactive, no secret needed. `backup.encrypt-key=<fingerprint>` in config is **not secret**.
+- **Restore (decrypt):** uses the user's **private** key via their real `~/.gnupg` (the `gpg-keys` interface); gpg-agent prompts for the key passphrase. **Interactive** — acceptable because restore is a deliberate manual step.
+- `snap get` exposes only the public-key fingerprint and target URL — useless to an attacker.
+- **Opt-out:** `backup.encrypt=false` runs `--no-encryption` (plaintext) with a loud warning; backup **refuses to run** if neither `backup.encrypt-key` is set nor `encrypt=false` is chosen.
+
+> Backend-credential caveat: `s3://`/`b2://` etc. credentials, if used, would still sit in `backup.*` config (root-readable). Backends that avoid on-box secrets: `scp`/`sftp` with an SSH key, or local/removable media. Documented; the user chooses.
+
+## Command surface
+
+A single `backup` app (root-required: it reads root-owned `$SNAP_DATA` and writes the archive cache), with subcommands:
+
+```
+zwave-js-ui.backup                 # ship $BACKUPS_DIR now (incremental; full if older than threshold)
+zwave-js-ui.backup restore [<time>]# fetch+decrypt latest (or at <time>) back into $BACKUPS_DIR
+zwave-js-ui.backup list            # duplicity collection-status (available backup sets)
+zwave-js-ui.backup status          # config + last-run summary
+zwave-js-ui.backup --help
+```
+
+- Unknown subcommand → usage + exit 2.
+- A separate snapd `timer:` daemon app runs `backup` on a schedule (see Scheduling).
+
+## Configuration (`snap set zwave-js-ui …`)
+
+Namespace `backup.*` (snapd config — distinct from ZUI's `settings.json` `backup.*`; documented to avoid confusion):
+
+| Key | Meaning | Default |
+|-----|---------|---------|
+| `backup.dir` | where ZUI writes backups and `backup` reads them; maps to `BACKUPS_DIR` (see "Source of truth") | `$SNAP_DATA/backups` |
+| `backup.target` | duplicity target URL (`file://`, `scp://`, `sftp://`, `s3://`, `b2://`, `webdav://`, …). Empty = backup disabled. | (unset) |
+| `backup.encrypt-key` | GPG public-key fingerprint to encrypt to (non-secret) | (unset) |
+| `backup.encrypt` | `false` to disable encryption (plaintext, warns) | `true` |
+| `backup.schedule` | snapd timer spec (e.g. `00:00`, `mon,03:00`); enables the timer | (unset = off) |
+| `backup.full-if-older-than` | force a new full chain after this age | `7D` |
+| `backup.retention` | prune: keep this many full chains (`remove-all-but-n-full`) | `3` |
+| backend creds | e.g. `backup.aws-access-key`, `backup.aws-secret-key`, `backup.b2-*` → mapped to duplicity's env vars | (unset) |
+
+`configure`/install seed no `backup.*` defaults beyond the documented behavior; backup stays off until `backup.target` is set.
+
+## Interfaces & staging (`snap/snapcraft.yaml`)
+
+- **Plugs** on the `backup` app: `network` (remote backends), `home` + `removable-media` (`file://` to user dirs / USB), `gpg-public-keys` (encrypt at backup time), `gpg-keys` (decrypt at restore time). `network` is already declared; the gpg interfaces are not auto-connect and need `snap connect` (documented).
+- **`stage-packages`:** `duplicity`, `gnupg`, and the commonly-used backend libs (ssh/paramiko, `python3-boto3` for s3, `b2sdk` for b2, webdav). Exotic backends (Dropbox/gdocs/Azure) documented as addable later, not staged.
+- **`BACKUPS_DIR`** is set *dynamically* from `backup.dir` (via the shared `backup_dir` helper), **not** a static `environment:` entry — `env-wrapper` exports it for the `zwave-js-ui`/`exec` apps, and `bin/backup` resolves the same helper for its source. (Static `environment:` can't read `snapctl`.)
+- **Timer app** for the optional schedule (a `daemon: oneshot` + `timer:` entry), gated on `backup.schedule`.
+
+## Restore flow
+
+`zwave-js-ui.backup restore [<time>]`:
+1. duplicity restores the `$BACKUPS_DIR` tree (latest, or at `<time>`) — decrypting via the user's private key (`gpg-keys`, interactive passphrase).
+2. Files land back in `$SNAP_DATA/backups/{nvm,store}/`.
+3. The command then **points the user at ZUI's in-app restore** (NVM restore + store restore) — ZUI performs the actual recovery. We never apply backups to the live store or stop the service.
+
+This keeps the fiddly, app-specific recovery in ZUI (its supported path) and limits our responsibility to delivering the files.
+
+## Error handling
+
+| Condition | Behavior |
+|-----------|----------|
+| `backup.target` unset | "backup not configured: set `backup.target`"; exit 0 (scheduled) / exit 1 (manual) |
+| `$BACKUPS_DIR` empty/absent | "nothing to back up (enable ZUI's scheduled backups in its settings)"; exit 0 |
+| No `backup.encrypt-key` and `encrypt` ≠ `false` | refuse with guidance; exit 1 |
+| Missing backend dep / bad creds | surface duplicity's error verbatim |
+| Restore without `gpg-keys` connected | hint: `sudo snap connect zwave-js-ui:gpg-keys` |
+| Not root | `require_root` (consistent with other service commands) |
+
+## Verification items (resolve during implementation, do not guess)
+
+1. **duplicity on core24 via `stage-packages`** — confirm the package set (duplicity + GnuPG + backend libs) stages and runs under confinement; confirm the binary path and that `--archive-dir`/`GNUPGHOME`/`HOME` are pointed at writable snap dirs.
+2. **GPG keyring mechanics under confinement** — where the public key lives at backup time (snap-local keyring in `$SNAP_COMMON/.gnupg` that the user imports into, vs `gpg-public-keys` reading `~/.gnupg`), and how restore reaches the user's private key via `gpg-keys` as root vs the invoking user. Pick the simplest that works; document the import/connect steps.
+3. **snapd `timer:` syntax** for `backup.schedule`, and how the timer app maps a `snap set` value to the timer (timers are declared in `snapcraft.yaml`, so a configurable schedule likely means the `configure` hook toggles/uses `snapctl` rather than rewriting YAML — confirm the mechanism).
+4. **`gpg-keys`/`gpg-public-keys` auto-connect** — whether to request store auto-connect or document manual `snap connect`.
+
+## Out of scope (YAGNI)
+
+- Creating Z-Wave backups (NVM/store) — that's ZUI's job; we only ship what exists.
+- Triggering ZUI to make a fresh backup via its API.
+- Backing up live store data or stopping the service.
+- Restoring directly into the running app (ZUI's in-app restore does this).
+- Staging every duplicity backend (only the common ones).

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -116,6 +116,25 @@ apps:
     command: bin/logs
     plugs:
       - log-observe
+  backup:
+    command: bin/backup
+    plugs:
+      - network
+      - home
+      - removable-media
+      - gpg-public-keys
+      - gpg-keys
+  backup-timer:
+    command: bin/backup
+    daemon: oneshot
+    timer: "00:00"
+    environment:
+      DAEMONIZED: 1
+    plugs:
+      - network
+      - home
+      - removable-media
+      - gpg-public-keys
 
 layout:
   # Cache is set to (env) something outside the rw mount, to prevent storing it inside the store dir.
@@ -179,3 +198,13 @@ parts:
       - uuid
     organize:
       hooks: snap/hooks
+
+  backup-deps:
+    plugin: nil
+    stage-packages:
+      - duplicity
+      - gnupg
+      - python3-boto3
+      - python3-b2sdk
+      - python3-paramiko
+      - python3-requests

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -50,7 +50,7 @@ build_backup_cmd() {           # $1 source dir -> duplicity backup command strin
 }
 
 build_restore_cmd() {          # $1 dest dir [$2 time] -> duplicity restore command string
-    local timearg=""; [ -n "${2:-}" ] && timearg="--time ${2}"
+    local timearg=""; [ -n "${2:-}" ] && timearg=$(printf -- '--time %q' "${2}")
     printf 'duplicity restore %s %s --archive-dir %q %q %q' \
         "$timearg" "$(encryption_args)" "$ARCHIVE_DIR" "$(cfg target)" "$1"
 }
@@ -72,14 +72,15 @@ main() {
     local sub; sub="$(parse_sub "${1:-}")" || { usage >&2; exit 2; }
 
     mkdir -p "$ARCHIVE_DIR"
-    export GNUPGHOME="${SNAP_COMMON}/.gnupg"   # snap-local keyring (confirmed by the GPG spike)
+    export GNUPGHOME="${SNAP_COMMON:-/tmp}/.gnupg"   # snap-local keyring (confirmed by the GPG spike)
 
     local target; target="$(cfg target)"
     case "$sub" in
         backup)
             if [ -z "$target" ]; then
                 lprint "Backup not configured: set 'snap set ${SNAP_NAME} backup.target=<duplicity-url>'." >&2
-                exit 1
+                # Quiet success for the scheduled (daemonized) timer; error for a manual run.
+                if [ "${DAEMONIZED:-0}" -eq 1 ]; then exit 0; else exit 1; fi
             fi
             if ! has_backups; then
                 lprint "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings."
@@ -97,12 +98,17 @@ main() {
         restore)
             [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
             local dest; dest="$(backup_dir)"; mkdir -p "$dest"
-            lprint "Restoring into ${dest}; you'll be prompted for your GPG key passphrase." >&2
+            if encryption_args 2>/dev/null | grep -q -- '--no-encryption'; then
+                lprint "Restoring into ${dest} (no encryption)." >&2
+            else
+                lprint "Restoring into ${dest}; you may be prompted for your GPG key passphrase." >&2
+            fi
             # shellcheck disable=SC2294
             eval "$(build_restore_cmd "$dest" "${2:-}")"
             lprint "Done. Now use ZUI's in-app restore (NVM / store) to recover." >&2
             ;;
         list)
+            [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
             # shellcheck disable=SC2294
             eval "$(build_list_cmd)"
             ;;

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -29,6 +29,19 @@ parse_sub() {                  # $1 subcommand token -> backup|restore|list|stat
     esac
 }
 
+cfg() { snapctl get "backup.$1" 2>/dev/null; }    # $1 = key suffix, e.g. target, encrypt-key
+
+encryption_args() {            # echoes "--encrypt-key X" or "--no-encryption"; status 2 if neither
+    local key; key=$(cfg encrypt-key)
+    if [ -n "$key" ]; then
+        echo "--encrypt-key $key"
+    elif [ "$(cfg encrypt)" = false ]; then
+        echo "--no-encryption"
+    else
+        return 2
+    fi
+}
+
 main() {
     : # assembled in a later task
 }

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -56,7 +56,7 @@ build_restore_cmd() {          # $1 dest dir [$2 time] -> duplicity restore comm
 }
 
 build_list_cmd() {             # -> duplicity collection-status command string
-    printf 'duplicity collection-status --archive-dir %q %q' "$ARCHIVE_DIR" "$(cfg target)"
+    printf 'duplicity collection-status %s --archive-dir %q %q' "$(encryption_args)" "$ARCHIVE_DIR" "$(cfg target)"
 }
 
 has_backups() {                # status 0 if backup_dir exists and is non-empty
@@ -83,7 +83,7 @@ main() {
                 if [ "${DAEMONIZED:-0}" -eq 1 ]; then exit 0; else exit 1; fi
             fi
             if ! has_backups; then
-                lprint "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings."
+                lprint "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings." >&2
                 exit 0
             fi
             if ! encryption_args >/dev/null 2>&1; then
@@ -97,6 +97,10 @@ main() {
             ;;
         restore)
             [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
+            if ! encryption_args >/dev/null 2>&1; then
+                lprint "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'." >&2
+                exit 1
+            fi
             local dest; dest="$(backup_dir)"; mkdir -p "$dest"
             if encryption_args 2>/dev/null | grep -q -- '--no-encryption'; then
                 lprint "Restoring into ${dest} (no encryption)." >&2
@@ -109,6 +113,10 @@ main() {
             ;;
         list)
             [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
+            if ! encryption_args >/dev/null 2>&1; then
+                lprint "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'." >&2
+                exit 1
+            fi
             # shellcheck disable=SC2294
             eval "$(build_list_cmd)"
             ;;

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -7,6 +7,28 @@ ARCHIVE_DIR="${SNAP_COMMON:-/tmp}/duplicity-cache"
 
 # ---- pure helpers (unit-tested) added by later tasks ----
 
+usage() {
+    cat <<EOF
+Usage: ${SNAP_NAME}.backup [restore [<time>] | list | status]
+
+  (no arg)   ship ZUI's backups now (incremental; full if older than threshold)
+  restore    fetch+decrypt the latest backup back into the backup dir
+  list       show available backup sets
+  status     show config + last run
+  -h|--help  this help
+EOF
+}
+
+parse_sub() {                  # $1 subcommand token -> backup|restore|list|status; status 2 if unknown
+    case "${1:-}" in
+        ""|backup) echo backup ;;
+        restore)   echo restore ;;
+        list)      echo list ;;
+        status)    echo status ;;
+        *)         return 2 ;;
+    esac
+}
+
 main() {
     : # assembled in a later task
 }

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -75,6 +75,10 @@ main() {
 
     mkdir -p "$ARCHIVE_DIR"
     export GNUPGHOME="${SNAP_COMMON:-/tmp}/.gnupg"   # snap-local keyring (confirmed by the GPG spike)
+    # duplicity is a Python app staged under $SNAP; core24's interpreter does not
+    # search $SNAP for modules, so its `import duplicity` fails without this
+    # (verified on-device: import works only with dist-packages on PYTHONPATH).
+    export PYTHONPATH="$SNAP/usr/lib/python3/dist-packages${PYTHONPATH:+:$PYTHONPATH}"
 
     local target; target="$(cfg target)"
     case "$sub" in
@@ -93,7 +97,10 @@ main() {
                 exit 1
             fi
             # shellcheck disable=SC2294
-            eval "$(build_backup_cmd "$(backup_dir)")"
+            if ! eval "$(build_backup_cmd "$(backup_dir)")"; then
+                lprint "Backup failed (duplicity exited non-zero)." >&2
+                exit 1
+            fi
             local keep; keep="$(cfg retention)"; keep="${keep:-3}"
             duplicity remove-all-but-n-full "$keep" --force --archive-dir "$ARCHIVE_DIR" "$target" || true
             ;;
@@ -110,7 +117,10 @@ main() {
                 lprint "Restoring into ${dest}; you may be prompted for your GPG key passphrase." >&2
             fi
             # shellcheck disable=SC2294
-            eval "$(build_restore_cmd "$dest" "${2:-}")"
+            if ! eval "$(build_restore_cmd "$dest" "${2:-}")"; then
+                lprint "Restore failed (duplicity exited non-zero)." >&2
+                exit 1
+            fi
             lprint "Done. Now use ZUI's in-app restore (NVM / store) to recover." >&2
             ;;
         list)

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -65,7 +65,51 @@ has_backups() {                # status 0 if backup_dir exists and is non-empty
 }
 
 main() {
-    : # assembled in a later task
+    case "${1:-}" in -h|--help) usage; exit 0 ;; esac
+
+    require_root
+
+    local sub; sub="$(parse_sub "${1:-}")" || { usage >&2; exit 2; }
+
+    mkdir -p "$ARCHIVE_DIR"
+    export GNUPGHOME="${SNAP_COMMON}/.gnupg"   # snap-local keyring (confirmed by the GPG spike)
+
+    local target; target="$(cfg target)"
+    case "$sub" in
+        backup)
+            if [ -z "$target" ]; then
+                lprint "Backup not configured: set 'snap set ${SNAP_NAME} backup.target=<duplicity-url>'." >&2
+                exit 1
+            fi
+            if ! has_backups; then
+                lprint "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings."
+                exit 0
+            fi
+            if ! encryption_args >/dev/null 2>&1; then
+                lprint "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'." >&2
+                exit 1
+            fi
+            # shellcheck disable=SC2294
+            eval "$(build_backup_cmd "$(backup_dir)")"
+            local keep; keep="$(cfg retention)"; keep="${keep:-3}"
+            duplicity remove-all-but-n-full "$keep" --force --archive-dir "$ARCHIVE_DIR" "$target" || true
+            ;;
+        restore)
+            [ -n "$target" ] || { lprint "backup.target not set." >&2; exit 1; }
+            local dest; dest="$(backup_dir)"; mkdir -p "$dest"
+            lprint "Restoring into ${dest}; you'll be prompted for your GPG key passphrase." >&2
+            # shellcheck disable=SC2294
+            eval "$(build_restore_cmd "$dest" "${2:-}")"
+            lprint "Done. Now use ZUI's in-app restore (NVM / store) to recover." >&2
+            ;;
+        list)
+            # shellcheck disable=SC2294
+            eval "$(build_list_cmd)"
+            ;;
+        status)
+            lprint "target=$(cfg target) dir=$(backup_dir) encrypt-key=$(cfg encrypt-key)"
+            ;;
+    esac
 }
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -42,6 +42,23 @@ encryption_args() {            # echoes "--encrypt-key X" or "--no-encryption"; 
     fi
 }
 
+full_if_older() { local v; v=$(cfg full-if-older-than); echo "${v:-7D}"; }
+
+build_backup_cmd() {           # $1 source dir -> duplicity backup command string
+    printf 'duplicity %s --full-if-older-than %s --archive-dir %q %q %q' \
+        "$(encryption_args)" "$(full_if_older)" "$ARCHIVE_DIR" "$1" "$(cfg target)"
+}
+
+build_restore_cmd() {          # $1 dest dir [$2 time] -> duplicity restore command string
+    local timearg=""; [ -n "${2:-}" ] && timearg="--time ${2}"
+    printf 'duplicity restore %s %s --archive-dir %q %q %q' \
+        "$timearg" "$(encryption_args)" "$ARCHIVE_DIR" "$(cfg target)" "$1"
+}
+
+build_list_cmd() {             # -> duplicity collection-status command string
+    printf 'duplicity collection-status --archive-dir %q %q' "$ARCHIVE_DIR" "$(cfg target)"
+}
+
 main() {
     : # assembled in a later task
 }

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -59,6 +59,11 @@ build_list_cmd() {             # -> duplicity collection-status command string
     printf 'duplicity collection-status --archive-dir %q %q' "$ARCHIVE_DIR" "$(cfg target)"
 }
 
+has_backups() {                # status 0 if backup_dir exists and is non-empty
+    local d; d="$(backup_dir)"
+    [ -d "$d" ] && [ -n "$(ls -A "$d" 2>/dev/null)" ]
+}
+
 main() {
     : # assembled in a later task
 }

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -1,3 +1,16 @@
 #!/usr/bin/env bash
+# backup — ship ZUI's backup directory off-box via duplicity
+: "${SNAP:?SNAP must be set}"
+source "$SNAP/helper/functions"
 
+ARCHIVE_DIR="${SNAP_COMMON:-/tmp}/duplicity-cache"
 
+# ---- pure helpers (unit-tested) added by later tasks ----
+
+main() {
+    : # assembled in a later task
+}
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    main "$@"
+fi

--- a/src/bin/backup
+++ b/src/bin/backup
@@ -9,13 +9,14 @@ ARCHIVE_DIR="${SNAP_COMMON:-/tmp}/duplicity-cache"
 
 usage() {
     cat <<EOF
-Usage: ${SNAP_NAME}.backup [restore [<time>] | list | status]
+Usage: ${SNAP_NAME}.backup [restore [<time>] | list | status | import-key]
 
-  (no arg)   ship ZUI's backups now (incremental; full if older than threshold)
-  restore    fetch+decrypt the latest backup back into the backup dir
-  list       show available backup sets
-  status     show config + last run
-  -h|--help  this help
+  (no arg)    ship ZUI's backups now (incremental; full if older than threshold)
+  restore     fetch+decrypt the latest backup back into the backup dir
+  list        show available backup sets
+  status      show current backup config
+  import-key  import a GPG public key (armored, read from stdin) into the snap keyring
+  -h|--help   this help
 EOF
 }
 
@@ -25,6 +26,7 @@ parse_sub() {                  # $1 subcommand token -> backup|restore|list|stat
         restore)   echo restore ;;
         list)      echo list ;;
         status)    echo status ;;
+        import-key) echo import-key ;;
         *)         return 2 ;;
     esac
 }
@@ -122,6 +124,14 @@ main() {
             ;;
         status)
             lprint "target=$(cfg target) dir=$(backup_dir) encrypt-key=$(cfg encrypt-key)"
+            ;;
+        import-key)
+            # Read an armored public key from stdin into the snap-local keyring.
+            # Asymmetric encryption keeps any decryption secret OFF the device, so
+            # we only ever import a *public* key here.
+            mkdir -p "$GNUPGHOME"; chmod 700 "$GNUPGHOME"
+            lprint "Importing armored GPG public key from stdin into ${GNUPGHOME} …" >&2
+            gpg --homedir "$GNUPGHOME" --import
             ;;
     esac
 }

--- a/src/helper/env-wrapper
+++ b/src/helper/env-wrapper
@@ -111,5 +111,6 @@ fi
 
 #export GIT_DIR="${SNAP}/lib/node_modules/zwave-js-ui/.git"
 export ZWAVEJS_LOGS_DIR="${STORE_DIR}/logs/zwavejs"
+BACKUPS_DIR="$(backup_dir)"; export BACKUPS_DIR
 
 [ "$(basename "${1}")" == "npm" ] && cd "${SNAP}/lib/node_modules/zwave-js-ui" && exec "${@}" || exec "${@}"

--- a/src/helper/functions
+++ b/src/helper/functions
@@ -93,12 +93,14 @@ function set_device_priority_dir {
 }
 
 function test_device_priority_dir {
-    set -x
-    ZUI_SETTINGS=$(zui_settings_file "w")
-    
-    if [ $? -ne 0 ]; then
-        echo "Cannot read/write to settings"
-        exit 1
+    # snapd copies $SNAP_DATA forward on every refresh, so settings.json is carried
+    # between revisions automatically — this function does NOT move config. Its only
+    # job is to rewrite a stale, revision-pinned deviceConfigPriorityDir (see below).
+    # If there's no settings.json yet (fresh install, or ZUI never started), there is
+    # nothing to migrate: no-op instead of aborting the hook with exit 1.
+    if ! ZUI_SETTINGS=$(zui_settings_file "w"); then
+        lprint "No writable settings.json yet; skipping deviceConfigPriorityDir migration."
+        return 0
     fi
 
     DEV_DIR=$(yq -re '.zwave.deviceConfigPriorityDir' "${ZUI_SETTINGS}" 2>&-)

--- a/src/helper/functions
+++ b/src/helper/functions
@@ -137,3 +137,8 @@ function test_default_config {
 
     testnset_config "timezone" "Europe/Oslo"
 }
+
+function backup_dir {
+    local d; d=$(snapctl get backup.dir 2>/dev/null)
+    echo "${d:-$SNAP_DATA/backups}"
+}

--- a/src/helper/functions
+++ b/src/helper/functions
@@ -2,7 +2,7 @@
 
 export ZWAVE_JS_CONF="${SNAP}/lib/node_modules/zwave-js-ui/node_modules/@zwave-js/config"
 
-if [ -z "${DAEMONIZED}" ]; then
+if [ -z "${DAEMONIZED:-}" ]; then
     DAEMONIZED=0
 fi
 

--- a/src/hooks/configure
+++ b/src/hooks/configure
@@ -22,6 +22,12 @@ if [ "${COOKIE_SECURE}" != true ] && [ "${COOKIE_SECURE}" != false ]; then
     exit 1
 fi
 
+BACKUP_DIR_CFG=$(snapctl get backup.dir)
+if [ -n "${BACKUP_DIR_CFG}" ] && [[ "${BACKUP_DIR_CFG}" != /* ]]; then
+    echo "!! backup.dir must be an absolute path, got ${BACKUP_DIR_CFG}" >&2
+    exit 1
+fi
+
 test_default_config
 
 # NB: keep `grep … | wc -l`, not `grep -c` — under `set -e`, grep -c exits 1 when the

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -47,4 +47,11 @@ assert_contains "$r" "file:///tgt"             "restore: target"
 l="$(SNAPCTL_backup_target=file:///tgt build_list_cmd)"
 assert_contains "$l" "collection-status"       "list: verb"
 
+rm -rf "$SNAP_DATA/backups"
+has_backups; assert_status "$?" "1" "absent dir -> no backups"
+mkdir -p "$SNAP_DATA/backups"
+has_backups; assert_status "$?" "1" "empty dir -> no backups"
+: > "$SNAP_DATA/backups/x"
+has_backups; assert_status "$?" "0" "non-empty -> has backups"
+
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+source "$HERE/lib/assert.sh"
+
+export SNAP="$HERE/fixtures"
+SNAP_DATA="$(mktemp -d)"; export SNAP_DATA
+SNAP_COMMON="$(mktemp -d)"; export SNAP_COMMON
+trap 'rm -rf "$SNAP_DATA" "$SNAP_COMMON"' EXIT
+
+# Test stub for snapctl: `snapctl get backup.foo-bar` reads $SNAPCTL_backup_foo_bar.
+snapctl() { case "$1" in get) local k="${2//[.-]/_}"; eval "printf '%s' \"\${SNAPCTL_${k}:-}\"" ;; *) : ;; esac; }
+
+# shellcheck source=/dev/null
+source "$ROOT/src/bin/backup"          # backup's own helpers (+ stub functions via $SNAP); main is guarded
+# shellcheck source=/dev/null
+source "$ROOT/src/helper/functions"    # REAL shared helpers (e.g. backup_dir), resolved against the snapctl stub above
+
+# --- tests appended by later tasks ---
+
+finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -29,4 +29,9 @@ assert_eq "$(parse_sub 'list')"    "list"    "list"
 assert_eq "$(parse_sub 'status')"  "status"  "status"
 parse_sub bogus >/dev/null 2>&1; assert_status "$?" "2" "unknown -> 2"
 
+assert_eq "$(SNAPCTL_backup_encrypt_key=ABC123 encryption_args)" "--encrypt-key ABC123" "enc key"
+assert_eq "$(SNAPCTL_backup_encrypt=false encryption_args)"      "--no-encryption"       "no-encryption opt-out"
+encryption_args >/dev/null 2>&1; assert_status "$?" "2" "neither set -> refuse"
+assert_eq "$(SNAPCTL_backup_target=file:///b cfg target)" "file:///b" "cfg reads target"
+
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -22,4 +22,11 @@ source "$ROOT/src/helper/functions"    # REAL shared helpers (e.g. backup_dir), 
 assert_eq "$(backup_dir)" "$SNAP_DATA/backups" "default backup dir"
 assert_eq "$(SNAPCTL_backup_dir=/srv/zui-backups backup_dir)" "/srv/zui-backups" "configured backup dir"
 
+assert_eq "$(parse_sub '')"        "backup"  "no arg -> backup"
+assert_eq "$(parse_sub 'backup')"  "backup"  "backup"
+assert_eq "$(parse_sub 'restore')" "restore" "restore"
+assert_eq "$(parse_sub 'list')"    "list"    "list"
+assert_eq "$(parse_sub 'status')"  "status"  "status"
+parse_sub bogus >/dev/null 2>&1; assert_status "$?" "2" "unknown -> 2"
+
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -34,4 +34,17 @@ assert_eq "$(SNAPCTL_backup_encrypt=false encryption_args)"      "--no-encryptio
 encryption_args >/dev/null 2>&1; assert_status "$?" "2" "neither set -> refuse"
 assert_eq "$(SNAPCTL_backup_target=file:///b cfg target)" "file:///b" "cfg reads target"
 
+src="$SNAP_DATA/backups"
+b="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt SNAPCTL_backup_full_if_older_than=7D build_backup_cmd "$src")"
+assert_contains "$b" "duplicity"               "backup: duplicity"
+assert_contains "$b" "--encrypt-key KEY"       "backup: enc key"
+assert_contains "$b" "--full-if-older-than 7D" "backup: full-if-older"
+assert_contains "$b" "--archive-dir"           "backup: archive-dir"
+assert_contains "$b" "file:///tgt"             "backup: target"
+r="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt build_restore_cmd "$SNAP_DATA/restore")"
+assert_contains "$r" "duplicity restore"       "restore: verb"
+assert_contains "$r" "file:///tgt"             "restore: target"
+l="$(SNAPCTL_backup_target=file:///tgt build_list_cmd)"
+assert_contains "$l" "collection-status"       "list: verb"
+
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -19,4 +19,7 @@ source "$ROOT/src/helper/functions"    # REAL shared helpers (e.g. backup_dir), 
 
 # --- tests appended by later tasks ---
 
+assert_eq "$(backup_dir)" "$SNAP_DATA/backups" "default backup dir"
+assert_eq "$(SNAPCTL_backup_dir=/srv/zui-backups backup_dir)" "/srv/zui-backups" "configured backup dir"
+
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -44,7 +44,7 @@ assert_contains "$b" "file:///tgt"             "backup: target"
 r="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt build_restore_cmd "$SNAP_DATA/restore")"
 assert_contains "$r" "duplicity restore"       "restore: verb"
 assert_contains "$r" "file:///tgt"             "restore: target"
-l="$(SNAPCTL_backup_target=file:///tgt build_list_cmd)"
+l="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt build_list_cmd)"
 assert_contains "$l" "collection-status"       "list: verb"
 
 rm -rf "$SNAP_DATA/backups"
@@ -53,5 +53,8 @@ mkdir -p "$SNAP_DATA/backups"
 has_backups; assert_status "$?" "1" "empty dir -> no backups"
 : > "$SNAP_DATA/backups/x"
 has_backups; assert_status "$?" "0" "non-empty -> has backups"
+
+rt="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt build_restore_cmd "$SNAP_DATA/restore" 2026-01-02)"
+assert_contains "$rt" "--time 2026-01-02" "restore: time arg quoted"
 
 finish

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -27,6 +27,7 @@ assert_eq "$(parse_sub 'backup')"  "backup"  "backup"
 assert_eq "$(parse_sub 'restore')" "restore" "restore"
 assert_eq "$(parse_sub 'list')"    "list"    "list"
 assert_eq "$(parse_sub 'status')"  "status"  "status"
+assert_eq "$(parse_sub 'import-key')" "import-key" "import-key"
 parse_sub bogus >/dev/null 2>&1; assert_status "$?" "2" "unknown -> 2"
 
 assert_eq "$(SNAPCTL_backup_encrypt_key=ABC123 encryption_args)" "--encrypt-key ABC123" "enc key"


### PR DESCRIPTION
## Summary

Adds **`zwave-js-ui.backup`**: a single-responsibility tool that ships ZUI's existing backup directory off-box via **duplicity** — encrypted (asymmetric GPG), incremental, with an optional daily timer — and restores it back for ZUI's in-app recovery. It does **not** create backups or touch live data; it relocates what ZUI already wrote. Implements `docs/superpowers/specs/2026-06-10-backup-design.md` (plan: `docs/superpowers/plans/2026-06-10-backup.md`).

- **Scope:** ships the whole `$BACKUPS_DIR` tree (= `$SNAP_DATA/backups`, ZUI's `nvm/*.bin` + `store/*.zip`). Empty/absent → clean no-op. No live data, **no service stop ever** (finalized files only).
- **One source of truth:** `backup.dir` → `BACKUPS_DIR`, resolved by a shared `backup_dir` helper used by both `env-wrapper` (ZUI, the writer) and `bin/backup` (the reader).
- **Encryption:** asymmetric — encrypt to a public key (`backup.encrypt-key`, non-secret); restore decrypts with your private key via the `gpg-keys` interface (interactive). Nothing secret in snap config. `backup.encrypt=false` opts out (warns); refuses if neither set.
- **Commands:** `backup` / `restore [<time>]` / `list` / `status`; all guard target + encryption coherence.
- **Schedule:** a fixed daily `backup-timer` (`daemon: oneshot`) that no-ops quietly until `backup.target` is set; daily-incremental + weekly-full via `--full-if-older-than`; pruned via `remove-all-but-n-full`.
- **Wiring:** `backup` + `backup-timer` apps, `backup-deps` stage-packages (duplicity + GnuPG + backends), plugs (`network`/`home`/`removable-media`/`gpg-public-keys`/`gpg-keys`); `configure` validates `backup.dir` is absolute.

## Test plan

- [x] 24 bash unit tests for the pure helpers (dir resolution, parsing, config, encryption flags, command builders, has_backups) — CI runs them (`lint-test.yml` now runs both suites)
- [x] `shellcheck --severity=warning` clean across all scripts
- [x] Reviewed: per-task spec+quality review, plus a dedicated `main` review and a whole-feature final review (must-fixes resolved: restore/list encryption guards, scheduled-vs-manual exit, CI wiring)
- [ ] **Launchpad build (this PR)** validates duplicity + backends stage under core24 confinement
- [ ] **On-device (maintainer):** install; `sudo snap connect zwave-js-ui:gpg-public-keys gpg-keys`; import your public key into the snap keyring; `snap set … backup.target=file:///… backup.encrypt-key=<fpr>`; enable ZUI's scheduled backups; then verify `backup` produces an encrypted set, `list` shows it, `restore` decrypts (interactive) into `$BACKUPS_DIR`, the timer no-ops when unconfigured, and `snap get … backup` reveals no secret. Full checklist in the plan's Task 14.

## Notes
- Builds on the merged audit cleanup (#189) — sits cleanly on current `main`.
- The on-device GPG keyring mechanics (root-vs-user) are the one area to confirm during validation; see the spec's verification items.