### PR TITLE
ci: run snap-release helper tests + shellcheck on PRs

### DIFF
--- a/.github/workflows/helper-tests.yml
+++ b/.github/workflows/helper-tests.yml
@@ -1,0 +1,27 @@
+name: Helper tests
+
+# Guards the CI helper that all the snap version/channel math depends on.
+# Runs only when the helper, its tests, or its fixtures change.
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - '.github/scripts/**'
+      - '.github/workflows/helper-tests.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Shellcheck the release helper + tests
+        run: shellcheck .github/scripts/snap-release.sh .github/scripts/snap-release.test.sh
+
+      - name: Run helper unit tests
+        run: bash .github/scripts/snap-release.test.sh


### PR DESCRIPTION
## Summary

Adds a small CI job that guards `.github/scripts/snap-release.sh` — the version/channel math that **both** `pr-build-snap.yml` and `release-on-merge.yml` depend on. Nothing ran its tests in CI before this.

## What it does

`helper-tests.yml` runs on PRs that touch `.github/scripts/**` (or the workflow itself), plus `workflow_dispatch`:
1. `shellcheck .github/scripts/snap-release.sh .github/scripts/snap-release.test.sh`
2. `bash .github/scripts/snap-release.test.sh` (23 fixture-driven unit tests)

Scoped via `paths:` so it only runs when the helper, its tests, or its fixtures change — consistent with the allowlist approach used by the build/release workflows.

## Notes

- The trigger also lists `helper-tests.yml` itself, so **this PR self-validates** (it adds that file → the job runs here).
- Verified locally: shellcheck clean, 23/23 tests pass.
- Independent of #192 (different files); either can merge first.