### PR TITLE
ci(pr-build): full clone so snapcraft remote-build works (fetch-depth: 0)

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -30,6 +30,10 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v6
+        with:
+          # snapcraft remote-build refuses shallow clones ("Remote builds for
+          # shallow cloned git repos are not supported"), so fetch full history.
+          fetch-depth: 0
 
       - name: Install snapcraft
         run: sudo snap install snapcraft --classic


### PR DESCRIPTION
## Summary

The `build-and-release` job in `pr-build-snap.yml` fails on **every** PR with:

> Remote builds for shallow cloned git repos are not supported

because the `Checkout` step uses the default shallow clone and `snapcraft remote-build` rejects it. This adds `fetch-depth: 0` so the full history is fetched and the remote-build can run.

One-line fix; affects all PR snap builds. (Discovered while validating PR #193.)

## Test plan
- [ ] This PR's own `build-and-release` check now gets past the shallow-clone error and proceeds to the Launchpad remote-build.