### PR TITLE
ci(pr-build): restore trailing newline in launchpad-credentials

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -42,7 +42,10 @@ jobs:
         run: |
           set -euo pipefail
           mkdir -p ~/.local/share/snapcraft
-          printf '%s' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
+          # Trailing newline matters: the pre-#191 working version used `echo` (which
+          # appends one); `printf '%s'` dropped it and Launchpad auth/push then failed.
+          # `%s\n` keeps printf's literal-safety AND restores the newline.
+          printf '%s\n' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
 
       - name: Resolve version / track / archs
         id: meta


### PR DESCRIPTION
## Summary

`snapcraft remote-build` fails to push to Launchpad (`Could not push 'HEAD' … refspec 'HEAD:refs/heads/main'`) — a Launchpad **auth** failure — since #191.

#191 rewrote the build pipeline and changed how the credentials file is written:
- **before (working):** `echo "$LAUNCHPAD_CREDENTIALS" > …`  → file ends in a **newline**
- **#191 → now:** `printf '%s' "$LAUNCHPAD_CREDENTIALS" > …`  → **no trailing newline**

The missing trailing newline breaks the credentials file launchpadlib reads, so remote-build can't authenticate and the push is rejected. (The build only reaches this step now because #195 fixed the earlier shallow-clone abort.)

Fix: `printf '%s\n'` — keeps `printf`'s literal-safety (no `echo` backslash quirks) **and** restores the trailing newline the working version had.

## Test plan
- [ ] This PR's `build-and-release` check authenticates to Launchpad and gets past the push (and ideally completes the remote build).

## Notes
- Discovered while diagnosing PR #193's build failure. This is a CI/release-pipeline regression, independent of any feature PR — it affects all PR snap builds.
- Hypothesis from the diff; the failed run's underlying git/auth error is in snapcraft's runner-local log (not uploaded), so the surest confirmation is this PR's build going green.