### PR TITLE
ci(pr-build): surface snapcraft log on build failure

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -71,6 +71,23 @@ jobs:
           count=$(ls -1 ./*.snap 2>/dev/null | wc -l | tr -d ' ')
           echo "snaps=$count" >> "$GITHUB_OUTPUT"
 
+      # remote-build writes its detailed error (e.g. the BadRequest reason) only to a
+      # log file on the runner, which is otherwise lost. Surface it when no snap built.
+      - name: Dump snapcraft log on build failure
+        if: ${{ always() && steps.build.outputs.snaps == '0' }}
+        run: |
+          shopt -s nullglob
+          logs=( ~/.local/state/snapcraft/log/*.log ~/.cache/snapcraft/log/*.log )
+          if [ ${#logs[@]} -eq 0 ]; then
+            echo "(no snapcraft log files found)"
+          else
+            for f in "${logs[@]}"; do
+              echo "::group::${f}"
+              cat "$f"
+              echo "::endgroup::"
+            done
+          fi
+
       - name: Ensure version track exists
         if: ${{ steps.build.outputs.snaps != '0' && github.event_name == 'pull_request' }}
         env:


### PR DESCRIPTION
## Summary

`snapcraft remote-build` writes its detailed error (the current blocker is a `snapcraft internal error: BadRequest()` after a successful push) only to a runner-local log file (`~/.local/state/snapcraft/log/*.log`), which isn't captured. #191's rewrite removed the old log-capture step, so build failures are currently undiagnosable.

This re-adds capture: when the build produces no `.snap`, `cat` the snapcraft log(s) into the job output (grouped) so the real failure reason is visible.

## Notes
- Diagnostics only — no behavior change to the build/publish itself.
- Like the other CI fixes, this `.github`-only change won't trigger its own build (paths allowlist = `snap/**`+`src/**`); it takes effect on the next code-PR build (e.g. #193 once it picks this up), which will then print the `BadRequest` detail.