### PR TITLE
fix(post-refresh): don't abort when settings.json is absent

### DIFF
--- a/src/helper/functions
+++ b/src/helper/functions
@@ -93,12 +93,14 @@ function set_device_priority_dir {
 }
 
 function test_device_priority_dir {
-    set -x
-    ZUI_SETTINGS=$(zui_settings_file "w")
-    
-    if [ $? -ne 0 ]; then
-        echo "Cannot read/write to settings"
-        exit 1
+    # snapd copies $SNAP_DATA forward on every refresh, so settings.json is carried
+    # between revisions automatically — this function does NOT move config. Its only
+    # job is to rewrite a stale, revision-pinned deviceConfigPriorityDir (see below).
+    # If there's no settings.json yet (fresh install, or ZUI never started), there is
+    # nothing to migrate: no-op instead of aborting the hook with exit 1.
+    if ! ZUI_SETTINGS=$(zui_settings_file "w"); then
+        lprint "No writable settings.json yet; skipping deviceConfigPriorityDir migration."
+        return 0
     fi
 
     DEV_DIR=$(yq -re '.zwave.deviceConfigPriorityDir' "${ZUI_SETTINGS}" 2>&-)


### PR DESCRIPTION
## Summary
`test_device_priority_dir` aborted the **post-refresh** hook with `exit 1` whenever `$SNAP_DATA/settings.json` did not exist (fresh install, or ZUI never started). Since the hook *sources* `functions`, that `exit 1` failed the entire refresh and snapd reverted it — making any new revision uninstallable until ZUI had written a settings file.

Root cause / clarification: snapd already copies `$SNAP_DATA` forward across revisions, so this function never *moves* config. Its sole purpose is to rewrite a stale, revision-pinned `deviceConfigPriorityDir` (e.g. one embedding the old `xN`/`current` path). "No settings.json yet" is a perfectly normal state and must be a no-op, not a fatal error.

## Changes
- No-op + `return 0` (with a log line) when there's no writable `settings.json`, instead of `echo … ; exit 1`.
- Drop a stray `set -x` that was spewing a `++ …` debug trace into the hook output.

## Test Plan
- [ ] `shellcheck --severity=warning src/helper/functions` passes (verified locally).
- [ ] Install a new revision over an existing one with **no** `settings.json` present → `post-refresh` completes, refresh succeeds (previously failed with "Cannot read/write to settings").
- [ ] With a `settings.json` containing a revision-pinned `deviceConfigPriorityDir`, the path is still rewritten to the current revision (existing behaviour preserved).