### PR TITLE
fix(logs): die when a followed stream needs journald without log-observe

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,6 +46,7 @@ zwave-js-ui.disable    # de-daemonize
 zwave-js-ui.restart
 zwave-js-ui.exec       # run the app in the foreground (debug boot issues before enabling)
 zwave-js-ui.logs       # unified, terminal-friendly live log view; append zui|zwjs to filter
+                       # dies (exit 1) if a followed stream logs to journald w/o log-observe connected
 zwave-js-ui.backup     # ship ZUI's backups off-box via duplicity (restore|list|status|pick-key|import-key|create-key|export-key)
 snap logs zwave-js-ui -f                  # manual fallback when "log to file" is OFF (syslog/journal)
 tail -f $SNAP_DATA/*.log                  # manual fallback when "log to file" is ON

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ Manage your Z-Wave network from the web interface:
 ## Snap-Specific Features
 
 This snap includes features that simplify running and managing Z-Wave JS UI on systems that use snaps:
-- Read logs from the terminal regardless of whether the application logs to file
+- Read logs from the terminal regardless of whether the application logs to file (`zwave-js-ui.logs`)
 - Optional integration with the `code-server` snap to edit files in the persistent store
 
 ## Auto-Connections
@@ -108,6 +108,7 @@ Manual connect/disconnect examples:
 
 Additional notes:
 - If you install the snap outside the Snap Store (for example with `snap install --dangerous`), the interfaces might not be auto-connected and you may need to run the connect commands above.
+- `zwave-js-ui.logs` reads journald for any log not written to file ("log to file" off, the upstream default). That requires the `log-observe` interface, which is **not** auto-connected — without it the command exits with an error that includes the fix: `sudo snap connect zwave-js-ui:log-observe`.
 - Depending on your distribution, you may also need to adjust USB device permissions or add your user to a serial/dialout group for direct access to the controller device node.
 - Granting the `raw-usb` interface gives the snap broad access to USB devices. Only enable it if you trust the snap source and understand the implications.
 

--- a/docs/superpowers/specs/2026-06-08-logs-command-design.md
+++ b/docs/superpowers/specs/2026-06-08-logs-command-design.md
@@ -89,7 +89,7 @@ Decide each stream's source by precedence — the filesystem is treated as groun
 |-----------|----------|
 | No `settings.json` (never configured) | Infer per Source resolution (→ journal by default); only show a friendly message if neither a file nor the journal yields anything. |
 | logToFile on but file absent | `tail -F` waits; emit a one-time "waiting for `<file>`" notice. |
-| `journalctl` denied / unavailable | Error with the `snap connect …:log-observe` hint. |
+| A followed stream resolves to journal while `log-observe` is unconnected | **Fatal: exit 1 before any follower launches**, naming the journald-backed stream(s) and printing the `snap connect …:log-observe` command. See the 2026-06-12 amendment. |
 | Not root (if required — see Verification) | `require_root`, consistent with `enable`/`disable`/`restart`. |
 
 ## Code & docs changes
@@ -121,3 +121,24 @@ Decide each stream's source by precedence — the filesystem is treated as groun
 - No timestamp-sorted global merge.
 - No log-level filtering.
 - No colorizing of log *content* (only labels).
+
+## Amendment 2026-06-12 — journald guard is fatal
+
+The first implementation softened the journal-denied case to a *warning* (probe
+`journalctl -n 0`, print the connect hint, launch the follower anyway). In
+practice `journalctl` dies instantly on the AppArmor denial and the command
+"succeeds" while showing nothing — confinement is per-snap, not per-UID, so
+`sudo` never helps. Amended behavior:
+
+- **Condition:** any *followed* stream resolves to the journal source while the
+  `log-observe` interface is unconnected. Checked with
+  `snapctl is-connected log-observe` (via the existing `plug_connected`
+  helper) — the stated condition itself, not a probe of its symptom.
+- **Behavior:** `require_journal_access` exits 1 with the stream label
+  (`journal_label`), the reason, and the connect command. `main` resolves all
+  selected streams **before** launching any follower, so death is a single
+  clean error with no half-started tails.
+- **Scope:** only streams being followed gate. A purely file-backed selection
+  (e.g. `logs zui` with `gateway.logToFile: true`) keeps working even when the
+  other stream is journald-backed without the interface — that request is
+  fully servable. The previous probe-and-warn block is removed.

--- a/src/bin/logs
+++ b/src/bin/logs
@@ -119,6 +119,18 @@ prefix_lines() {               # $1 prefix; prepends to each stdin line
 
 journal_unit() { echo "snap.${SNAP_NAME}.${SNAP_NAME}.service"; }
 
+require_journal_access() {     # $@ journald-backed streams; dies unless log-observe is connected
+    # Confinement is per-snap, not per-UID: even under sudo, journald stays
+    # unreadable until the log-observe interface is connected — so a journald-
+    # backed stream without it can only ever produce silence. Die instead.
+    [ "$#" -gt 0 ] || return 0
+    local msg
+    if msg="$(plug_connected log-observe)"; then return 0; fi
+    lprint "$(journal_label "$@") logs to journald ('log to file' is off), which cannot be read without the log-observe interface." >&2
+    lprint "$msg" >&2
+    exit 1
+}
+
 follower_cmd() {               # $1 source spec, $2 backlog -> a %q-quoted command string
     local spec="$1" n="$2"
     case "$spec" in
@@ -156,24 +168,34 @@ main() {
 
     local sf; sf="$(settings_file)"
     local BACKLOG=20
-    local pids=() journal_streams=() s setting src p other
+    local pids=() journal_streams=() file_streams=() file_srcs=() s setting src p other i
 
-    # Register cleanup BEFORE launching anything, so a Ctrl-C mid-launch still reaps every
-    # follower subshell AND its children (tail/journalctl + prefixer). Empty pids = no-op.
-    trap 'for p in "${pids[@]}"; do pkill -P "$p" 2>/dev/null; kill "$p" 2>/dev/null; done' EXIT INT TERM
-
+    # Resolve every followed stream BEFORE launching anything: if one of them needs
+    # journald while log-observe is unconnected, die up front with a single clear
+    # error instead of half-starting tails next to a journalctl that shows silence.
     for s in "${streams[@]}"; do
         setting="$(read_log_setting "$sf" "$(setting_key "$s")")"
         src="$(resolve_source "$s" "$setting")"
         if [ "$src" = journal ]; then
             journal_streams+=("$s")
         else
-            # If the file doesn't exist yet (e.g. logToFile just enabled), tail -F waits
-            # silently — tell the user what it's waiting for.
-            [ -e "${src#file:}" ] || lprint "Waiting for log file: ${src#file:}" >&2
-            launch_follower "$src" "$(make_prefix "$(stream_upper "$s")" "$(stream_color "$s")" "$use_color")"
-            pids+=("$!")
+            file_streams+=("$s"); file_srcs+=("$src")
         fi
+    done
+
+    require_journal_access "${journal_streams[@]}"
+
+    # Register cleanup BEFORE launching anything, so a Ctrl-C mid-launch still reaps every
+    # follower subshell AND its children (tail/journalctl + prefixer). Empty pids = no-op.
+    trap 'for p in "${pids[@]}"; do pkill -P "$p" 2>/dev/null; kill "$p" 2>/dev/null; done' EXIT INT TERM
+
+    for i in "${!file_streams[@]}"; do
+        s="${file_streams[$i]}"; src="${file_srcs[$i]}"
+        # If the file doesn't exist yet (e.g. logToFile just enabled), tail -F waits
+        # silently — tell the user what it's waiting for.
+        [ -e "${src#file:}" ] || lprint "Waiting for log file: ${src#file:}" >&2
+        launch_follower "$src" "$(make_prefix "$(stream_upper "$s")" "$(stream_color "$s")" "$use_color")"
+        pids+=("$!")
     done
 
     if [ "${#journal_streams[@]}" -gt 0 ]; then
@@ -185,11 +207,6 @@ main() {
             if [ "$(resolve_source "$other" "$(read_log_setting "$sf" "$(setting_key "$other")")")" = journal ]; then
                 lprint "Note: ${target} and ${other} share one journald stream; ${other} lines may also appear." >&2
             fi
-        fi
-        # Probe journal access; on denial, point the user at the interface to connect.
-        if ! journalctl -u "$(journal_unit)" -n 0 >/dev/null 2>&1; then
-            lprint "Cannot read the journal (permission?). Connect the interface with:" >&2
-            lprint "  sudo snap connect ${SNAP_NAME}:log-observe" >&2
         fi
         launch_follower journal "$(make_prefix "$(journal_label "${journal_streams[@]}")" yellow "$use_color")"
         pids+=("$!")

--- a/tests/fixtures/bin/journalctl
+++ b/tests/fixtures/bin/journalctl
@@ -1,0 +1,3 @@
+#!/usr/bin/env bash
+# Test stub: succeed instantly so main's `wait` returns instead of following forever.
+exit 0

--- a/tests/fixtures/bin/tail
+++ b/tests/fixtures/bin/tail
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+# Test stub: optionally record that a follower launched, then exit at once
+# so main's `wait` returns instead of following forever.
+[ -z "${TAIL_SENTINEL:-}" ] || : > "$TAIL_SENTINEL"
+exit 0

--- a/tests/fixtures/helper/functions
+++ b/tests/fixtures/helper/functions
@@ -2,3 +2,15 @@
 SNAP_NAME="zwave-js-ui"
 lprint() { echo "$*"; }
 require_root() { :; }   # no-op under test
+
+# Mirrors the real helper's contract (prints connect instructions, returns 1)
+# without snapctl: a plug counts as connected iff listed in $TEST_CONNECTED_PLUGS.
+plug_connected() {
+    case " ${TEST_CONNECTED_PLUGS:-} " in
+        *" $1 "*) return 0 ;;
+    esac
+    echo "Missing plug: «$1»"
+    echo "Connect with:"
+    echo "$ sudo snap connect ${SNAP_NAME}:$1"
+    return 1
+}

--- a/tests/logs_test.sh
+++ b/tests/logs_test.sh
@@ -78,4 +78,46 @@ assert_contains "$(follower_cmd 'file:/var/log/zui_current.log' 20)" "zui_curren
 assert_contains "$(follower_cmd journal 20)" "journalctl -u" "journal -> journalctl"
 assert_contains "$(follower_cmd journal 20)" "snap.zwave-js-ui.zwave-js-ui.service" "journal -> unit"
 
+# ---- journald guard: a journald-backed stream is unreadable without log-observe ----
+STUB_BIN="$HERE/fixtures/bin"   # instant-exit tail/journalctl so main's `wait` returns
+
+# require_journal_access: no journald-backed streams -> no-op, plug irrelevant
+( export TEST_CONNECTED_PLUGS=""; require_journal_access ) >/dev/null 2>&1
+assert_status "$?" "0" "guard: no journald streams -> ok"
+
+# connected -> passes silently
+out="$( ( export TEST_CONNECTED_PLUGS="log-observe"; require_journal_access zui ) 2>&1 )"; st=$?
+assert_status "$st" "0" "guard: plug connected -> ok"
+assert_eq "$out" "" "guard: plug connected -> silent"
+
+# journald-backed + plug missing -> dies with the why and the fix
+out="$( ( export TEST_CONNECTED_PLUGS=""; require_journal_access zui zwjs ) 2>&1 )"; st=$?
+assert_status "$st" "1" "guard: missing plug -> exit 1"
+assert_contains "$out" "ZUI/ZWJS" "guard: names the journald streams"
+assert_contains "$out" "journald" "guard: says why"
+assert_contains "$out" "snap connect zwave-js-ui:log-observe" "guard: connect instructions"
+
+# main: a followed journald stream w/o the plug kills the command BEFORE any
+# follower launches — the file-backed stream must not have been tailed.
+printf '%s' '{"gateway":{"logToFile":true},"zwave":{"logToFile":false}}' > "$SNAP_DATA/settings.json"
+out="$( ( PATH="$STUB_BIN:$PATH"; export TAIL_SENTINEL="$SNAP_DATA/tail.ran"; export TEST_CONNECTED_PLUGS=""; main ) 2>&1 )"; st=$?
+assert_status "$st" "1" "main: journald stream w/o plug -> exit 1"
+assert_contains "$out" "snap connect zwave-js-ui:log-observe" "main: death message has the fix"
+[ ! -e "$SNAP_DATA/tail.ran" ]; assert_status "$?" "0" "main: no follower launched before death"
+
+# main: all streams journald-backed w/o plug -> same death
+printf '%s' '{"gateway":{"logToFile":false},"zwave":{"logToFile":false}}' > "$SNAP_DATA/settings.json"
+( PATH="$STUB_BIN:$PATH"; export TEST_CONNECTED_PLUGS=""; main ) >/dev/null 2>&1
+assert_status "$?" "1" "main: all-journald w/o plug -> exit 1"
+
+# main: a purely file-backed selection still works — only FOLLOWED streams gate
+printf '%s' '{"gateway":{"logToFile":true},"zwave":{"logToFile":false}}' > "$SNAP_DATA/settings.json"
+( PATH="$STUB_BIN:$PATH"; export TEST_CONNECTED_PLUGS=""; main zui ) >/dev/null 2>&1
+assert_status "$?" "0" "main: file-backed selection unaffected by missing plug"
+
+# main: journald-backed WITH the plug connected -> follows the journal
+printf '%s' '{"gateway":{"logToFile":false},"zwave":{"logToFile":false}}' > "$SNAP_DATA/settings.json"
+( PATH="$STUB_BIN:$PATH"; export TEST_CONNECTED_PLUGS="log-observe"; main ) >/dev/null 2>&1
+assert_status "$?" "0" "main: connected -> follows journal"
+
 finish


### PR DESCRIPTION
## Problem

When a followed stream is journald-backed (`logToFile` off — the upstream default) and the `log-observe` interface is not connected, `zwave-js-ui.logs` only printed a warning and launched the follower anyway. `journalctl` dies instantly on the AppArmor denial (confinement is per-snap, not per-UID, so `sudo` never helps), and the command "succeeded" while showing silence. The original spec already called for an error here; the implementation had softened it to a warning.

## Change

- New `require_journal_access()`: checks the stated condition itself — `snapctl is-connected log-observe` via the existing `plug_connected` helper — instead of probing `journalctl` and guessing at the cause. On failure it exits 1 naming the journald-backed stream(s), the reason, and the exact fix:

  ```
  ZWJS logs to journald ('log to file' is off), which cannot be read without the log-observe interface.
  Missing plug: «log-observe»
  Connect with:
  $ sudo snap connect zwave-js-ui:log-observe
  ```

- `main` resolves **all** selected streams before launching any follower, so the death is a single clean error with no half-started tails. The old probe/warning block is removed.
- Scope: only streams **being followed** gate. `logs zui` with ZUI logging to file keeps working even when ZWJS is journald-backed without the plug — that request is fully servable from the file. Plain `logs` (both) dies if either logger is journald-backed.

## Tests

TDD red→green: 11 new assertions watched failing against the old behavior (exit 0), now `48 passed, 0 failed`; backup suite unaffected (`42 passed, 0 failed`); CI's `shellcheck --severity=warning -x` invocation clean.

`main()` is now exercised end-to-end: a `plug_connected` fixture stub (driven by `TEST_CONNECTED_PLUGS`) plus instant-exit `tail`/`journalctl` PATH stubs let `wait` return, including a sentinel assertion that no follower launches before the death.

## Docs

- Amendment section + error-table row in `docs/superpowers/specs/2026-06-08-logs-command-design.md`
- README: note that `log-observe` is **not** auto-connected and the command exits with the fix
- CLAUDE.md: command-list note