### PR TITLE
refactor: salvage net-new simplifications from #207 (env-wrapper cd-guard fix + backup DRY)

### DIFF
--- a/src/bin/backup
+++ b/src/bin/backup
@@ -87,7 +87,7 @@ cmd_status() {                 # render current backup config as a table
     local target key onbox="no" retention timer
     target="$(cfg target)"
     key="$(cfg encrypt-key)"
-    if [ -n "$key" ] && gpg --no-autostart --homedir "$GNUPGHOME" --list-secret-keys "$key" >/dev/null 2>&1; then
+    if [ -n "$key" ] && gpg_snap --list-secret-keys "$key" >/dev/null 2>&1; then
         onbox="yes"
     fi
     retention="$(cfg retention)"
@@ -120,6 +120,13 @@ nth_fpr() {
     case "${1:-}" in ''|*[!0-9]*) return 1 ;; esac
     awk -F'\t' -v n="$1" 'NR==n{print $1; f=1; exit} END{exit !f}'
 }
+
+# Every gpg call against the SNAP keyring shares the same two flags: --homedir $GNUPGHOME
+# (the snap-local keyring, exported in main) and --no-autostart (gpg must not try to spawn
+# the base-path agent that doesn't exist in the snap; secret-key ops launch the staged one
+# via ensure_agent and connect over its socket). Centralise them here. NB: pick-key targets
+# the USER's host keyring, not $GNUPGHOME, so it does NOT use this wrapper.
+gpg_snap() { gpg --no-autostart --homedir "$GNUPGHOME" "$@"; }
 
 # USER-context: list the invoking user's host public keys, or export one (armored) to
 # stdout. Refuses root (root can't read the user's keyring — owner-match fails). Pipe the
@@ -210,14 +217,14 @@ cmd_import_key() {
     local tmp; tmp="$(mktemp "${SNAP_COMMON:-/tmp}/.import-key.XXXXXX")"
     trap 'rm -f "$tmp"' RETURN
     cat > "$tmp"
-    # --no-autostart: importing a PUBLIC key needs no gpg-agent; without this, gpg tries
-    # to autostart the (base-path, absent-in-snap) agent and exits non-zero even though
-    # the import succeeded. See the gpg-agent packaging note for the secret-key paths.
-    local fpr; fpr="$(gpg --no-autostart --homedir "$GNUPGHOME" --show-keys --with-colons "$tmp" 2>/dev/null | first_fpr)"
+    # gpg_snap carries --no-autostart: importing a PUBLIC key needs no gpg-agent; without
+    # it gpg tries to autostart the (base-path, absent-in-snap) agent and exits non-zero
+    # even though the import succeeded. See the gpg-agent packaging note for secret-key ops.
+    local fpr; fpr="$(gpg_snap --show-keys --with-colons "$tmp" 2>/dev/null | first_fpr)"
     # gpg's import chatter (incl. host-agent version warnings) confuses more than it
     # informs — keep it for the failure path only, where it is the diagnostic.
     local gpgout
-    if ! gpgout="$(gpg --no-autostart --homedir "$GNUPGHOME" --import "$tmp" 2>&1)"; then
+    if ! gpgout="$(gpg_snap --import "$tmp" 2>&1)"; then
         ui_err "Key import failed — backup.encrypt-key not changed. gpg said:"
         printf '%s\n' "$gpgout" >&2
         return 1
@@ -226,7 +233,7 @@ cmd_import_key() {
         # Mark the designated backup key ultimately trusted in this dedicated keyring, so
         # gpg/duplicity will encrypt to it non-interactively. Without a trust path an
         # imported public key is "Unusable" for batch encryption.
-        printf '%s:6:\n' "$fpr" | gpg --no-autostart --homedir "$GNUPGHOME" --import-ownertrust 2>/dev/null
+        printf '%s:6:\n' "$fpr" | gpg_snap --import-ownertrust 2>/dev/null
         snapctl set backup.encrypt-key="$fpr"
         ui_ok "Imported ${fpr} (trusted) and set backup.encrypt-key=${fpr}."
     else
@@ -289,18 +296,18 @@ cmd_create_key() {
     uid="$uid <$email>"
     # gpg chatter (trustdb, revocation-cert notes) only on failure, where it explains.
     local gpgout
-    if ! gpgout="$(gpg --no-autostart --homedir "$GNUPGHOME" --batch --pinentry-mode loopback --passphrase "$pass" \
+    if ! gpgout="$(gpg_snap --batch --pinentry-mode loopback --passphrase "$pass" \
         --quick-generate-key "$uid" ed25519 cert,sign never 2>&1)"; then
         ui_err "Key generation failed — check the name/email are valid. gpg said:"
         printf '%s\n' "$gpgout" >&2
         return 1
     fi
-    local fpr; fpr="$(gpg --no-autostart --homedir "$GNUPGHOME" --list-keys --with-colons "$email" 2>/dev/null | first_fpr)"
+    local fpr; fpr="$(gpg_snap --list-keys --with-colons "$email" 2>/dev/null | first_fpr)"
     if [ -z "$fpr" ]; then
         ui_err "Key was generated but its fingerprint could not be read for '${email}'."
         return 1
     fi
-    if ! gpgout="$(gpg --no-autostart --homedir "$GNUPGHOME" --batch --pinentry-mode loopback --passphrase "$pass" \
+    if ! gpgout="$(gpg_snap --batch --pinentry-mode loopback --passphrase "$pass" \
         --quick-add-key "$fpr" cv25519 encr never 2>&1)"; then
         ui_err "Adding the encryption subkey failed; '${fpr}' is not usable for backups yet. gpg said:"
         printf '%s\n' "$gpgout" >&2
@@ -325,7 +332,7 @@ cmd_export_key() {
     fi
     local fpr; fpr="$(cfg encrypt-key)"
     [ -n "$fpr" ] || { ui_err "backup.encrypt-key not set; nothing to export."; exit 1; }
-    if ! gpg --no-autostart --homedir "$GNUPGHOME" --list-secret-keys "$fpr" >/dev/null 2>&1; then
+    if ! gpg_snap --list-secret-keys "$fpr" >/dev/null 2>&1; then
         ui_print "No private key on this device for ${fpr} (public-only or card key); nothing to export." >&2
         exit 0
     fi
@@ -335,7 +342,7 @@ cmd_export_key() {
     # stderr to a scratch file: it must not pollute the armored stdout, and gpg's
     # notes only help when the export FAILS (pinentry itself draws on the tty).
     local exported gpgerr; gpgerr="$(mktemp "${SNAP_COMMON:-/tmp}/.export-key-err.XXXXXX")"
-    if ! exported="$(gpg --no-autostart --homedir "$GNUPGHOME" --export-secret-keys --armor "$fpr" 2>"$gpgerr")" || [ -z "$exported" ]; then
+    if ! exported="$(gpg_snap --export-secret-keys --armor "$fpr" 2>"$gpgerr")" || [ -z "$exported" ]; then
         ui_err "Export failed or produced no output — aborting. The private key has NOT been deleted. gpg said:"
         cat "$gpgerr" >&2; rm -f "$gpgerr"
         exit 1
@@ -346,7 +353,7 @@ cmd_export_key() {
     case "$?" in
         0)
             local delout
-            if ! delout="$(gpg --no-autostart --homedir "$GNUPGHOME" --batch --yes --delete-secret-keys "$fpr" 2>&1)"; then
+            if ! delout="$(gpg_snap --batch --yes --delete-secret-keys "$fpr" 2>&1)"; then
                 ui_err "Failed to delete the private key — it may still be present in the snap keyring. gpg said:"
                 printf '%s\n' "$delout" >&2
                 exit 1
@@ -371,6 +378,22 @@ encryption_args() {            # echoes "--encrypt-key X" or "--no-encryption"; 
 }
 
 full_if_older() { local v; v=$(cfg full-if-older-than); echo "${v:-7D}"; }
+retention()     { local v; v=$(cfg retention);          echo "${v:-3}"; }
+
+# Preconditions shared by the backup/restore/list actions. Each prints guidance and exits
+# non-zero when unmet, matching the inline checks they replaced. (The `backup` action keeps
+# its own target check — it stays quiet for the daemonized timer instead of exiting 1.)
+require_target() {
+    [ -n "$(cfg target)" ] && return 0
+    ui_err "backup.target not set."
+    exit 1
+}
+
+require_encryption_config() {
+    encryption_args >/dev/null 2>&1 && return 0
+    ui_err "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'."
+    exit 1
+}
 
 # gdrive:// auth: duplicity reads a Google service-account JSON from
 # GOOGLE_SERVICE_JSON_FILE. Export it when backup.gdrive-credentials is set;
@@ -455,24 +478,17 @@ main() {
                 ui_print "Nothing to back up in $(backup_dir) — enable ZUI's scheduled backups in its settings." >&2
                 exit 0
             fi
-            if ! encryption_args >/dev/null 2>&1; then
-                ui_err "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'."
-                exit 1
-            fi
+            require_encryption_config
             # shellcheck disable=SC2294
             if ! eval "$(build_backup_cmd "$(backup_dir)")"; then
                 ui_err "Backup failed (duplicity exited non-zero)."
                 exit 1
             fi
-            local keep; keep="$(cfg retention)"; keep="${keep:-3}"
-            "$DUP_PY" -m duplicity remove-all-but-n-full "$keep" --force --archive-dir "$ARCHIVE_DIR" "$target" || true
+            "$DUP_PY" -m duplicity remove-all-but-n-full "$(retention)" --force --archive-dir "$ARCHIVE_DIR" "$target" || true
             ;;
         restore)
-            [ -n "$target" ] || { ui_err "backup.target not set."; exit 1; }
-            if ! encryption_args >/dev/null 2>&1; then
-                ui_err "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'."
-                exit 1
-            fi
+            require_target
+            require_encryption_config
             local dest; dest="$(backup_dir)"; mkdir -p "$dest"
             if encryption_args 2>/dev/null | grep -q -- '--no-encryption'; then
                 ui_print "Restoring into ${dest} (no encryption)." >&2
@@ -493,11 +509,8 @@ main() {
             ui_print "Done. Now use ZUI's in-app restore (NVM / store) to recover." >&2
             ;;
         list)
-            [ -n "$target" ] || { ui_err "backup.target not set."; exit 1; }
-            if ! encryption_args >/dev/null 2>&1; then
-                ui_err "Set 'backup.encrypt-key=<gpg-fpr>' or opt out with 'backup.encrypt=false'."
-                exit 1
-            fi
+            require_target
+            require_encryption_config
             local raw rows
             # shellcheck disable=SC2294
             raw="$(eval "$(build_list_cmd)")" || { ui_err "Listing failed (duplicity exited non-zero)."; exit 1; }

--- a/src/helper/env-wrapper
+++ b/src/helper/env-wrapper
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-source $SNAP/helper/functions
+source "$SNAP/helper/functions"
 
 require_root
 
@@ -41,8 +41,13 @@ if [ -n "$(snapctl get timezone)" ]; then
     TZ=$(snapctl get timezone); export TZ
 fi
 
-#export GIT_DIR="${SNAP}/lib/node_modules/zwave-js-ui/.git"
 export ZWAVEJS_LOGS_DIR="${STORE_DIR}/logs/zwavejs"
 BACKUPS_DIR="$(backup_dir)"; export BACKUPS_DIR
 
-[ "$(basename "${1}")" == "npm" ] && cd "${SNAP}/lib/node_modules/zwave-js-ui" && exec "${@}" || exec "${@}"
+# When chained ahead of `npm`, run it from the app's module dir so its subcommands
+# resolve; otherwise exec the target as-is. Explicit if/then avoids the `A && B || C`
+# pitfall where a failed `cd` would silently fall through to an un-chdir'd exec.
+if [ "$(basename "${1}")" = "npm" ]; then
+    cd "${SNAP}/lib/node_modules/zwave-js-ui" || exit 1
+fi
+exec "${@}"


### PR DESCRIPTION
## Context

#207 (KISS/DRY/LIM audit) collided with the now-merged **#202** (gum CLI UI), which independently refactored the same files. After analysis, most of #207 is **superseded**: `src/bin/help` entirely (main's catalog-driven version is better) and `env-wrapper`'s `--help` removal (already on main). This PR salvages only the **net-new** parts onto current `main`. It **supersedes #207** (which can be closed in its favor).

## Changes

- **`src/helper/env-wrapper`** — *bug fix:* the npm chain was `… && cd … && exec "$@" || exec "$@"`, so a failed `cd` would silently `exec` in the wrong directory. Now an explicit `if … then cd … || exit 1; fi; exec "$@"`. Also quotes the `source` and drops a dead commented-out line.
- **`src/bin/backup`** — DRY extraction, **additive** (preserves all of #202's `ui_*` layer): `gpg_snap()` (de-dupes `--no-autostart --homedir` across 9 call sites), `require_target()`, `require_encryption_config()`, `retention()`. The extracted preconditions keep `ui_err` (not `lprint`).

Skipped: `src/bin/help` — superseded by #202.

## Tests

`shellcheck --severity=warning -x` clean; `tests/backup_test.sh` 67/67 pass; the `help` fixture is committed on `main` so the full suite is green in CI.
