### PR TITLE
ci(build): retry transient snapcraft upload failures

### DIFF
--- a/.github/scripts/retry.sh
+++ b/.github/scripts/retry.sh
@@ -1,0 +1,28 @@
+#!/usr/bin/env bash
+# retry.sh — run a command, retrying on failure to ride out TRANSIENT errors
+# (network blips on remote store / Launchpad operations: artifact fetch, snap
+# upload, track creation). Bounded: a genuinely-broken command still fails after
+# <max-attempts>, but a one-off connection drop no longer fails the build.
+#
+# Usage:  retry.sh <max-attempts> <delay-seconds> -- <command> [args...]
+# Exit:   0 on first success; otherwise the LAST attempt's exit status.
+set -uo pipefail
+
+max="${1:?usage: retry.sh <max-attempts> <delay-seconds> -- cmd ...}"
+delay="${2:?usage: retry.sh <max-attempts> <delay-seconds> -- cmd ...}"
+shift 2
+[ "${1:-}" = "--" ] && shift
+[ "$#" -gt 0 ] || { echo "retry.sh: no command given" >&2; exit 2; }
+
+attempt=1
+while true; do
+    "$@" && exit 0
+    rc=$?
+    if [ "$attempt" -ge "$max" ]; then
+        echo "retry.sh: '$1' failed after ${attempt} attempt(s) (exit ${rc})" >&2
+        exit "$rc"
+    fi
+    echo "retry.sh: '$1' failed (exit ${rc}); retry ${attempt}/${max} in ${delay}s" >&2
+    sleep "$delay"
+    attempt=$((attempt + 1))
+done

--- a/.github/scripts/retry.test.sh
+++ b/.github/scripts/retry.test.sh
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+# Unit tests for retry.sh. No network: a stub command counts attempts in a file
+# and succeeds once it reaches a threshold, so retry behaviour is deterministic.
+set -uo pipefail
+
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+RETRY="$HERE/retry.sh"
+fail=0
+check() { # desc expected actual
+  if [ "$2" = "$3" ]; then
+    printf 'ok   - %s\n' "$1"
+  else
+    printf 'FAIL - %s\n       expected: [%s]\n       actual:   [%s]\n' "$1" "$2" "$3"
+    fail=1
+  fi
+}
+
+work="$(mktemp -d)"; trap 'rm -rf "$work"' EXIT
+# Stub command: bump counter file ($1), succeed once it reaches threshold ($2).
+# shellcheck disable=SC2016  # $1/$2 are bash -c positional args — intentionally literal
+FLAKY='n=0; [ -f "$1" ] && n=$(cat "$1"); n=$((n+1)); printf %s "$n" >"$1"; [ "$n" -ge "$2" ]'
+
+st="$work/a"; "$RETRY" 3 0 -- bash -c "$FLAKY" _ "$st" 1; rc=$?
+check "success first try: exit 0"        "0" "$rc"
+check "success first try: ran once"      "1" "$(cat "$st")"
+
+st="$work/b"; "$RETRY" 3 0 -- bash -c "$FLAKY" _ "$st" 3; rc=$?
+check "recovers on 3rd attempt: exit 0"  "0" "$rc"
+check "recovers on 3rd attempt: ran 3x"  "3" "$(cat "$st")"
+
+st="$work/c"; "$RETRY" 2 0 -- bash -c "$FLAKY" _ "$st" 99; rc=$?
+check "exhausts attempts: nonzero exit"  "1" "$rc"
+check "exhausts attempts: ran max twice" "2" "$(cat "$st")"
+
+"$RETRY" 1 0 -- bash -c 'exit 7'; check "propagates command exit code" "7" "$?"
+"$RETRY" 3 0 -- 2>/dev/null;       check "no command -> usage exit 2"   "2" "$?"
+
+[ "$fail" -eq 0 ] && echo "All retry tests passed." || echo "Some retry tests FAILED."
+exit "$fail"

--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -128,7 +128,10 @@ jobs:
             f="$(ls -1 "${SNAP_NAME}"*"${arch}".snap 2>/dev/null | head -n1 || true)"
             if [ -z "$f" ]; then echo "missing snap for $arch"; missing+=("$arch"); continue; fi
             echo "Uploading $f -> $CHAN"
-            if snapcraft upload "$f" --release="$CHAN"; then uploaded+=("$arch"); else echo "upload failed for $arch"; missing+=("$arch"); fi
+            # Retry the store upload: it can drop mid-transfer ("Connection aborted /
+            # RemoteDisconnected") on an otherwise-valid snap — a transient blip must not
+            # fail the build. Bounded, so a genuine rejection still fails. See retry.test.sh.
+            if .github/scripts/retry.sh 3 15 -- snapcraft upload "$f" --release="$CHAN"; then uploaded+=("$arch"); else echo "upload failed for $arch"; missing+=("$arch"); fi
           done
           {
             echo "channel=$CHAN"


### PR DESCRIPTION
## Problem
A snap arch can build and validate fine, then **fail to publish** when the Snap Store upload drops mid-transfer — `('Connection aborted.', RemoteDisconnected('Remote end closed connection without response'))`. Observed on **armhf** in PR #211's build: amd64/arm64 uploaded, armhf's connection died after unsquash, and the build went red on an otherwise-good snap.

This is the same class of transient network failure the **download** path already handles (`remote-build.sh` retries the Launchpad fetch), but the **upload** step had no retry.

## Fix
- **`.github/scripts/retry.sh`** — a small, generic bounded-retry wrapper: `retry.sh <max> <delay> -- <cmd...>`. Returns 0 on first success, the last attempt's exit status otherwise. Reusable for any flaky remote op (upload, fetch, track-create).
- Wrap `snapcraft upload` in it (3 attempts, 15s apart) in `pr-build-snap.yml`. A genuine rejection still fails after the attempts; only transient blips are absorbed.

## Tests
`retry.test.sh` (stub-driven, no network): first-try success, recover-on-Nth-attempt, exhaust-then-fail, exit-code propagation, usage error. `helper-tests.yml` already shellchecks `.github/scripts/*.sh` and runs every `*.test.sh`, so this is covered automatically. All 4 CI-script suites pass; shellcheck clean.

## Note
On a retry, if a prior attempt created a store revision before the connection dropped, a duplicate revision is possible — harmless for the per-PR `edge` channel (the release points at the latest). The observed armhf failure created **no** revision (the transfer died before commit), so the retry simply completes it.
