### PR TITLE
chore(ui): tidy ui_stack trailing blank + ui_pager test redundancy

### DIFF
--- a/src/helper/ui
+++ b/src/helper/ui
@@ -132,10 +132,12 @@ ui_table_width() {             # [headers...]; stdin TSV -> natural bordered-tab
 
 ui_stack() {                   # [headers...]; stdin TSV -> generic stacked records
                                # col-1 = title; later columns = indented "header: value" (bare if no header)
-    local headers=("$@") line i
+    local headers=("$@") line i first=1
     local -a fields
     while IFS= read -r line; do
         IFS=$'\t' read -ra fields <<< "$line"
+        # blank line BETWEEN records, not a trailing one after the last
+        [ "$first" -eq 1 ] && first=0 || printf '\n'
         printf '%s\n' "${fields[0]}"
         for i in "${!fields[@]}"; do
             [ "$i" -eq 0 ] && continue
@@ -145,7 +147,6 @@ ui_stack() {                   # [headers...]; stdin TSV -> generic stacked reco
                 printf '    %s\n' "${fields[$i]}"
             fi
         done
-        printf '\n'
     done
 }
 

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -216,13 +216,12 @@ big="$(seq 1 50)"
 assert_contains "$(printf '%s\n' "$big" | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager)" "[pager]" "pager: styled + overflow -> gum pager"
 # fits -> passthrough (no pager)
 fits="$(printf 'a\nb\n' | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager)"
-assert_eq "$fits" "$(printf 'a\nb')" "pager: fits -> passthrough"
-case "$fits" in *'[pager]'*) FAIL=$((FAIL+1)); echo "FAIL: paged content that fit" >&2 ;; *) PASS=$((PASS+1)) ;; esac
+assert_eq "$fits" "$(printf 'a\nb')" "pager: fits -> passthrough (exact equality also proves no [pager])"
 # plain ctx -> passthrough even when tall
 plain="$(printf '%s\n' "$big" | NO_COLOR=1 UI_LINES=10 ui_pager)"
 case "$plain" in *'[pager]'*) FAIL=$((FAIL+1)); echo "FAIL: plain ctx paged" >&2 ;; *) PASS=$((PASS+1)) ;; esac
 assert_contains "$plain" "50" "pager: plain passthrough keeps content"
-# gates on stdout: content arrives on a pipe (stdin not a tty) yet styled -> still pages
-assert_contains "$(printf '%s\n' "$big" | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager)" "[pager]" "pager: piped stdin + styled still pages"
+# Note: ui_pager gates on stdout (ui_ctx), not stdin — every case above already
+# pipes content in (stdin not a tty), so test 1 covers "piped + styled -> pages".
 
 finish


### PR DESCRIPTION
Small, non-functional tidy-up of the review-deferred **minor** findings from the responsive-UI work that landed in #211 (no behaviour change to any command).

- **`ui_stack`** emitted a blank line after *every* record including the last, leaving a trailing blank below stacked `help`/`backup` output. Now the blank is a separator *between* records only.
- **`ui_pager` tests**: removed (a) the redundant `case` check that re-counted the same assertion already covered by the `fits -> passthrough` `assert_eq`, and (b) the 4th test that was byte-identical to test 1 — `ui_pager` gates on stdout, not stdin, and every case already pipes content in, so test 1 covers "piped + styled → pages". Replaced both with clarifying comments.

No production behaviour changes; `ui_stack` output loses only a trailing blank line. Full suite green (normal + `TERM=dumb` CI parity), shellcheck `--severity=warning -x` clean.

(The Part B review minors — the journald-die doc note and the empty-pager comment — are handled in #213, where that code lives.)
