### PR TITLE
fix(release): per-channel floor for latest/* promotion (no silent downgrade)

### DIFF
--- a/.github/scripts/snap-release.sh
+++ b/.github/scripts/snap-release.sh
@@ -10,6 +10,8 @@
 #   branch-has-revisions <track> <pr>  (stdin: `snapcraft status`) -> yes|no
 #   needs-stable-bump <new> <cand>     yes iff cand set & major(new)>major(cand)
 #   is-at-least <ver> <floor>          yes iff ver>=floor  (floor "" -> yes)
+#   latest-targets <new> <cand> <edge> latest/* channels <new> may land on, each gated by
+#                                      new >= that channel's own ver (no downgrade); space-sep
 set -euo pipefail
 
 # numeric major.minor.patch compare; echoes -1|0|1 (leading 'v' stripped)
@@ -24,6 +26,12 @@ _vercmp() {
     if (( 10#$x < 10#$y )); then echo -1; return; fi
   done
   echo 0
+}
+
+# true (exit 0) iff ver >= floor; empty floor => true. Leading 'v' optional.
+_at_least() {
+  [ -z "${2:-}" ] && return 0
+  [ "$(_vercmp "${1:-}" "$2")" -ge 0 ]
 }
 
 cmd="${1:-}"; shift || true
@@ -69,10 +77,17 @@ case "$cmd" in
     if (( 10#$mn > 10#$mc )); then echo yes; else echo no; fi
     ;;
   is-at-least)
-    ver="${1:-}"; floor="${2:-}"
-    if [ -z "$floor" ]; then echo yes; exit 0; fi
-    c="$(_vercmp "$ver" "$floor")"
-    if [ "$c" -ge 0 ]; then echo yes; else echo no; fi
+    if _at_least "${1:-}" "${2:-}"; then echo yes; else echo no; fi
+    ;;
+  latest-targets)
+    # args: <new-ver> <latest/candidate ver> <latest/edge ver>.
+    # Echo the latest/* channels <new-ver> may land on — each gated independently by
+    # <new-ver> >= that channel's OWN current version, so a backport can never downgrade
+    # a shared channel already ahead. Empty floor (channel currently empty) => qualifies.
+    v="${1:-}"; out=""
+    if _at_least "$v" "${2:-}"; then out="$out latest/candidate"; fi
+    if _at_least "$v" "${3:-}"; then out="$out latest/edge"; fi
+    echo "${out# }"
     ;;
   *)
     echo "snap-release.sh: unknown subcommand: ${cmd:-<none>}" >&2

--- a/.github/scripts/snap-release.test.sh
+++ b/.github/scripts/snap-release.test.sh
@@ -54,4 +54,13 @@ check "is-at-least lesser"       "no"  "$("$SR" is-at-least v11.5.0 v11.19.0)"
 check "is-at-least empty-floor"  "yes" "$("$SR" is-at-least v11.0.0 "")"
 check "is-at-least minor-numeric" "yes" "$("$SR" is-at-least v11.20.0 v11.9.0)"
 
+# latest-targets <new> <latest/candidate ver> <latest/edge ver> -> space-sep latest/* channels
+# <new> may land on, each gated by <new> >= that channel's OWN version (no downgrades).
+check "latest-targets both-newer"   "latest/candidate latest/edge" "$("$SR" latest-targets v11.21.0 v11.20.0 v11.20.0)"
+check "latest-targets equal"        "latest/candidate latest/edge" "$("$SR" latest-targets v11.20.0 v11.20.0 v11.20.0)"
+check "latest-targets edge-ahead"   "latest/candidate"             "$("$SR" latest-targets v11.20.0 v11.20.0 v11.21.0)"
+check "latest-targets cand-ahead"   "latest/edge"                  "$("$SR" latest-targets v11.20.0 v11.21.0 v11.20.0)"
+check "latest-targets backport"     ""                             "$("$SR" latest-targets v11.19.0 v11.20.0 v11.20.0)"
+check "latest-targets empty-floors" "latest/candidate latest/edge" "$("$SR" latest-targets v11.20.0 "" "")"
+
 exit "$fail"

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -84,13 +84,17 @@ jobs:
           echo ">> $BRANCH -> $TRACK/stable"
           snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$TRACK/stable" --yes
 
-          # 3) Shared latest/* only if this isn't a backport.
-          if [ "$("$SR" is-at-least "$V" "$CAND")" = "yes" ]; then
-            echo ">> $BRANCH -> latest/candidate, latest/edge"
-            snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/candidate --yes
-            snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/edge --yes
+          # 3) Shared latest/* — promote each channel only if $V is >= that channel's OWN
+          #    current version, so a backport can never downgrade a channel already ahead.
+          EDGE="$("$SR" channel-version latest/edge <<<"$INFO")"
+          TARGETS="$("$SR" latest-targets "$V" "$CAND" "$EDGE")"
+          if [ -n "$TARGETS" ]; then
+            for ch in $TARGETS; do
+              echo ">> $BRANCH -> $ch"
+              snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$ch" --yes
+            done
           else
-            echo ">> backport ($V < $CAND): leaving latest/* unchanged"
+            echo ">> backport ($V; candidate=${CAND:-<none>} edge=${EDGE:-<none>}): leaving latest/* unchanged"
           fi
 
           # 4) Close the PR branch (auto-expires anyway; this is tidy-up).


### PR DESCRIPTION
## Why

Follow-up to #215. `release-on-merge` step 3 gated **both** `latest/candidate` and `latest/edge` with a single check against `latest/candidate`'s version (`is-at-least $V $CAND`). That's correct only while `latest/edge == latest/candidate` — which holds today, since `release-on-merge` is their only writer and sets them together. But it's a latent footgun: if `latest/edge` ever sits ahead of `latest/candidate` (e.g. a separate edge publisher — the snap README notes "every build might be pushed to edge"), a backport with `candidate ≤ V < edge` would pass the shared guard and **downgrade `latest/edge`** — the exact "older version replaces a newer one" regression we want to prevent.

## What

- New tested helper `snap-release.sh latest-targets <new> <cand-ver> <edge-ver>` → the `latest/*` channels `<new>` may land on, each gated **independently** by `<new> >= that channel's OWN current version` (empty floor ⇒ qualifies). 6 unit tests, including the `edge-ahead` downgrade case.
- DRY: extracted `_at_least` (shared by `is-at-least` and `latest-targets`); `is-at-least`'s existing tests guard the refactor.
- `release-on-merge.yml` step 3 now reads `latest/edge`'s version too and loops over `latest-targets` instead of the single shared guard.

`latest/stable` (major-bump-only; only ever moves forward) and `v<MM>/stable` (the version's own track) are unchanged — already correct.

## Tests

33/33 helper unit tests; shellcheck clean. Simulated against live channel state (candidate = edge = v11.20.0): a v11.19.x backport yields **no** latest/* targets; v11.20.0 / v11.21.0 / v12.0.0 yield both.
