### PR TITLE
ci: split build/release for selective re-run (per-arch)

### DIFF
--- a/.github/scripts/pr-comment.sh
+++ b/.github/scripts/pr-comment.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# pr-comment.sh — render the sticky PR-build comment body for pr-build-snap.yml.
+# Pure: args in, markdown on stdout, no network. Unit-tested by pr-comment.test.sh.
+#
+# Usage:  pr-comment.sh <channel> <wanted-csv> <published-csv>
+#   <wanted-csv>    archs the build targeted, e.g. "amd64,arm64,armhf"
+#   <published-csv> archs that reached the channel (may be empty)
+# Env:    SNAP_NAME (default zwave-js-ui)
+set -euo pipefail
+
+chan="${1:?usage: pr-comment.sh <channel> <wanted-csv> <published-csv>}"
+wanted="${2:-}"
+published="${3:-}"
+snap="${SNAP_NAME:-zwave-js-ui}"
+
+# csv -> sorted-unique newline list (empties dropped)
+to_lines() { printf '%s' "${1:-}" | tr ',' '\n' | sed '/^$/d' | sort -u; }
+w="$(to_lines "$wanted")"
+p="$(to_lines "$published")"
+count() { printf '%s\n' "${1}" | sed '/^$/d' | wc -l | tr -d ' '; }
+nw="$(count "$w")"
+np="$(count "$p")"
+
+join_csv() { printf '%s\n' "${1}" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'; }
+avail="$(join_csv "$p")"
+failed="$(comm -23 <(printf '%s\n' "$w" | sed '/^$/d') <(printf '%s\n' "$p" | sed '/^$/d') | { tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'; })"
+
+if [ "$np" -eq 0 ]; then
+    printf '❌ No architectures were published for this PR.\n'
+    exit 0
+fi
+
+if [ -z "$failed" ]; then
+    printf "✅ Published to \`%s\` — available to install & test:\n\n" "$chan"
+    printf '  Architectures: %s\n' "$avail"
+    note="auto-selects your arch"
+else
+    printf "⚠️ Partial publish to \`%s\` — %s of %s architectures.\n\n" "$chan" "$np" "$nw"
+    printf '  Available for: %s\n' "$avail"
+    note="works on: $avail"
+fi
+printf '  sudo snap install %s --channel=%s      # %s\n' "$snap" "$chan" "$note"
+printf '  # or: sudo snap refresh %s --channel=%s\n' "$snap" "$chan"
+if [ -n "$failed" ]; then
+    printf '\n  ❌ Failed: %s — use "Re-run failed jobs" to retry just that arch (no rebuild of the published archs).\n' "$failed"
+fi

--- a/.github/scripts/pr-comment.sh
+++ b/.github/scripts/pr-comment.sh
@@ -17,13 +17,14 @@ snap="${SNAP_NAME:-zwave-js-ui}"
 to_lines() { printf '%s' "${1:-}" | tr ',' '\n' | sed '/^$/d' | sort -u; }
 w="$(to_lines "$wanted")"
 p="$(to_lines "$published")"
-count() { printf '%s\n' "${1}" | sed '/^$/d' | wc -l | tr -d ' '; }
+count() { printf '%s\n' "${1:-}" | sed '/^$/d' | wc -l | tr -d ' '; }
 nw="$(count "$w")"
 np="$(count "$p")"
 
-join_csv() { printf '%s\n' "${1}" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'; }
+join_csv() { printf '%s\n' "${1:-}" | sed '/^$/d' | tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'; }
 avail="$(join_csv "$p")"
-failed="$(comm -23 <(printf '%s\n' "$w" | sed '/^$/d') <(printf '%s\n' "$p" | sed '/^$/d') | { tr '\n' ',' | sed 's/,$//' | sed 's/,/, /g'; })"
+failed="$(comm -23 <(printf '%s\n' "$w" | sed '/^$/d') <(printf '%s\n' "$p" | sed '/^$/d'))"
+failed="$(join_csv "$failed")"
 
 if [ "$np" -eq 0 ]; then
     printf '❌ No architectures were published for this PR.\n'

--- a/.github/scripts/pr-comment.test.sh
+++ b/.github/scripts/pr-comment.test.sh
@@ -26,6 +26,15 @@ hasnt "partial: armhf not avail" "$part" "Available for: amd64, arm64, armhf"
 
 none="$("$PC" "$CH" "amd64,arm64,armhf" "")"
 has   "none: nothing published"  "$none" "❌ No architectures were published"
+hasnt "none: no install command" "$none" "sudo snap install"
+
+dflt="$(env -u SNAP_NAME "$PC" "$CH" "amd64" "amd64")"
+has "default snap name when SNAP_NAME unset" "$dflt" "sudo snap install zwave-js-ui --channel=$CH"
+
+single="$("$PC" "$CH" "amd64" "amd64")"
+has   "single: success header"   "$single" "✅ Published to \`$CH\`"
+has   "single: architectures"    "$single" "Architectures: amd64"
+hasnt "single: no failed line"   "$single" "❌ Failed:"
 
 [ "$fail" -eq 0 ] && echo "All pr-comment tests passed." || echo "Some pr-comment tests FAILED."
 exit "$fail"

--- a/.github/scripts/pr-comment.test.sh
+++ b/.github/scripts/pr-comment.test.sh
@@ -1,0 +1,31 @@
+#!/usr/bin/env bash
+# Unit tests for pr-comment.sh. Pure: no network. Asserts the three renderings.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PC="$HERE/pr-comment.sh"
+export SNAP_NAME=zwave-js-ui
+fail=0
+has()  { if printf '%s' "$2" | grep -qF -- "$3"; then printf 'ok   - %s\n' "$1"; else printf 'FAIL - %s\n       missing: [%s]\n       in:      [%s]\n' "$1" "$3" "$2"; fail=1; fi; }
+hasnt(){ if printf '%s' "$2" | grep -qF -- "$3"; then printf 'FAIL - %s\n       unexpected: [%s]\n' "$1" "$3"; fail=1; else printf 'ok   - %s\n' "$1"; fi; }
+
+CH="v11.21/edge/210"
+
+all="$("$PC" "$CH" "amd64,arm64,armhf" "amd64,arm64,armhf")"
+has   "all: success header"      "$all" "✅ Published to \`$CH\`"
+has   "all: lists every arch"    "$all" "Architectures: amd64, arm64, armhf"
+has   "all: install command"     "$all" "sudo snap install zwave-js-ui --channel=$CH"
+has   "all: auto-selects note"   "$all" "auto-selects your arch"
+hasnt "all: no failed line"      "$all" "❌ Failed:"
+
+part="$("$PC" "$CH" "amd64,arm64,armhf" "amd64,arm64")"
+has   "partial: warn header"     "$part" "⚠️ Partial publish to \`$CH\` — 2 of 3"
+has   "partial: available list"  "$part" "Available for: amd64, arm64"
+has   "partial: works-on note"   "$part" "works on: amd64, arm64"
+has   "partial: failed arch"     "$part" "❌ Failed: armhf"
+hasnt "partial: armhf not avail" "$part" "Available for: amd64, arm64, armhf"
+
+none="$("$PC" "$CH" "amd64,arm64,armhf" "")"
+has   "none: nothing published"  "$none" "❌ No architectures were published"
+
+[ "$fail" -eq 0 ] && echo "All pr-comment tests passed." || echo "Some pr-comment tests FAILED."
+exit "$fail"

--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -123,6 +123,7 @@ jobs:
           path: ${{ env.BUILDLOG }}
           retention-days: 1
           if-no-files-found: ignore
+          overwrite: true   # "Re-run failed jobs" re-runs this leg; replace the prior attempt's log
 
   upload:
     needs: [meta, build, ensure-track]

--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -5,11 +5,8 @@ on:
     branches: [main]
     types: [opened, synchronize, reopened]
     # Only the snap recipe and its bundled inputs affect the built artifact, so
-    # build + publish to v<MM>/edge/<PR> ONLY when those change. Everything else
-    # (docs, LICENSE, .gitignore, .github/**, renovate.json, editor config) is
-    # intentionally excluded — a doc/config edit must not mint a store revision.
-    # requirements-duplicity.txt IS a build input: snapcraft pip-installs it into
-    # the artifact, and Renovate opens requirements-only bump PRs for it.
+    # build + publish ONLY when those change. Docs/config edits must not mint a
+    # store revision. requirements-duplicity.txt IS a build input (pip-installed).
     paths:
       - 'snap/**'
       - 'src/**'
@@ -28,162 +25,221 @@ env:
   SNAP_NAME: zwave-js-ui
 
 jobs:
-  build-and-release:
+  meta:
     runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      track: ${{ steps.meta.outputs.track }}
+      archs: ${{ steps.meta.outputs.archs }}
+      archs_csv: ${{ steps.meta.outputs.archs_csv }}
     steps:
-      - name: Checkout
-        uses: actions/checkout@v7
-        with:
-          # snapcraft remote-build refuses shallow clones ("Remote builds for
-          # shallow cloned git repos are not supported"), so fetch full history.
-          fetch-depth: 0
-
-      - name: Install snapcraft
-        run: sudo snap install snapcraft --classic
-
-      - name: Configure Launchpad credentials
-        run: |
-          set -euo pipefail
-          mkdir -p ~/.local/share/snapcraft
-          # Trailing newline matters: the pre-#191 working version used `echo` (which
-          # appends one); `printf '%s'` dropped it and Launchpad auth/push then failed.
-          # `%s\n` keeps printf's literal-safety AND restores the newline.
-          printf '%s\n' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
-
+      - uses: actions/checkout@v7
       - name: Resolve version / track / archs
         id: meta
         run: |
           set -euo pipefail
           V="$(yq '.version' snap/snapcraft.yaml)"
           TRACK="$(.github/scripts/snap-release.sh version-to-track "$V")"
-          ARCHS="$(yq '.platforms | keys | join(",")' snap/snapcraft.yaml)"
+          ARCHS_JSON="$(yq -o=json -I=0 '.platforms | keys' snap/snapcraft.yaml)"
+          ARCHS_CSV="$(yq '.platforms | keys | join(",")' snap/snapcraft.yaml)"
           {
             echo "version=$V"
             echo "track=$TRACK"
-            echo "archs=$ARCHS"
+            echo "archs=$ARCHS_JSON"
+            echo "archs_csv=$ARCHS_CSV"
           } >> "$GITHUB_OUTPUT"
 
-      # Builds + fetches every arch, retrying when a transient network error
-      # truncates the artifact DOWNLOAD (the Launchpad build itself succeeds).
-      # Validates each .snap, drops truncated ones, and re-fetches via --recover
-      # (no rebuild). Still tolerant of a genuine partial-arch build failure.
-      # Writes steps.build.outputs.snaps=<valid-count>. See remote-build.test.sh.
-      - name: Remote-build all archs (retry transient fetch failures)
-        id: build
-        run: .github/scripts/remote-build.sh "${{ steps.meta.outputs.archs }}"
-
-      # remote-build writes its detailed error (e.g. the BadRequest reason) only to a
-      # log file on the runner, which is otherwise lost. Surface it when no snap built.
-      - name: Dump snapcraft log on build failure
-        id: sclog
-        if: ${{ always() && steps.build.outputs.snaps == '0' }}
-        run: |
-          shopt -s nullglob
-          logs=( ~/.local/state/snapcraft/log/*.log ~/.cache/snapcraft/log/*.log )
-          tail_file="${RUNNER_TEMP}/snapcraft-log-tail.txt"; : > "$tail_file"
-          if [ ${#logs[@]} -eq 0 ]; then
-            echo "(no snapcraft log files found)" | tee -a "$tail_file"
-          else
-            for f in "${logs[@]}"; do
-              echo "::group::${f}"
-              cat "$f"
-              echo "::endgroup::"
-              { echo "===== ${f} ====="; cat "$f"; } >> "$tail_file"
-            done
-          fi
-          # Keep only the last 50 KB for the PR comment (well under GitHub's ~65 KB limit).
-          tail -c 50000 "$tail_file" > "${tail_file}.cut" && mv "${tail_file}.cut" "$tail_file"
-          echo "tail_file=${tail_file}" >> "$GITHUB_OUTPUT"
-
+  # Runs in parallel with the builds: it only needs the track NAME, so a failed
+  # build never blocks or skips it. Idempotent (the script checks existence first).
+  ensure-track:
+    needs: meta
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+      SNAPCRAFT_SESSION_COOKIE: ${{ secrets.SNAPCRAFT_SESSION_COOKIE }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
       - name: Ensure version track exists
-        if: ${{ steps.build.outputs.snaps != '0' && github.event_name == 'pull_request' }}
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
-          SNAPCRAFT_SESSION_COOKIE: ${{ secrets.SNAPCRAFT_SESSION_COOKIE }}
         run: |
           set -euo pipefail
-          TRACK="${{ steps.meta.outputs.track }}"
-          # Listing tracks uses the macaroon (SNAPCRAFT_STORE_CREDENTIALS); skip if it exists.
+          TRACK="${{ needs.meta.outputs.track }}"
+          # Listing tracks uses the macaroon; skip create if it already exists.
           if snapcraft tracks "$SNAP_NAME" | awk 'NR>1{print $1}' | grep -qx "$TRACK"; then
             echo "Track $TRACK already exists."
             exit 0
           fi
-          # Creating a track has no snapcraft command — it needs the storefront session cookie.
           bash .github/scripts/snap-create-track.sh "$SNAP_NAME" "$TRACK"
 
-      - name: Upload built archs to v<MM>/edge/<PR>
-        id: release
-        if: ${{ steps.build.outputs.snaps != '0' && github.event_name == 'pull_request' }}
-        env:
-          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+  build:
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false           # a dead arch must not cancel its siblings
+      matrix:
+        arch: ${{ fromJSON(needs.meta.outputs.archs) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0         # snapcraft remote-build refuses shallow clones
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Configure Launchpad credentials
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.local/share/snapcraft
+          printf '%s\n' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
+      - name: Remote-build ${{ matrix.arch }}
+        id: build
+        run: .github/scripts/remote-build.sh "${{ matrix.arch }}"
+      - name: Upload snap artifact
+        if: ${{ steps.build.outputs.snaps != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: ${{ env.SNAP_NAME }}*${{ matrix.arch }}.snap
+          retention-days: 1
+          if-no-files-found: error
+      - name: Capture snapcraft log on failure
+        if: ${{ always() && steps.build.outputs.snaps == '0' }}
+        run: |
+          shopt -s nullglob
+          logs=( ~/.local/state/snapcraft/log/*.log ~/.cache/snapcraft/log/*.log )
+          out="${RUNNER_TEMP}/buildlog-${{ matrix.arch }}.txt"; : > "$out"
+          if [ ${#logs[@]} -eq 0 ]; then
+            echo "(no snapcraft log files found for ${{ matrix.arch }})" >> "$out"
+          else
+            for f in "${logs[@]}"; do { echo "===== $f ====="; cat "$f"; } >> "$out"; done
+          fi
+          tail -c 50000 "$out" > "$out.cut" && mv "$out.cut" "$out"
+          echo "BUILDLOG=$out" >> "$GITHUB_ENV"
+      - name: Upload snapcraft log artifact
+        if: ${{ always() && steps.build.outputs.snaps == '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: buildlog-${{ matrix.arch }}
+          path: ${{ env.BUILDLOG }}
+          retention-days: 1
+          if-no-files-found: ignore
+
+  upload:
+    needs: [meta, build, ensure-track]
+    # Run even though `build` reports failure from a sibling arch (!cancelled),
+    # but only once the track exists.
+    if: ${{ !cancelled() && needs.ensure-track.result == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(needs.meta.outputs.archs) }}
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: .
+        continue-on-error: true   # missing => this arch's build failed; handled below
+      - name: Upload to v<MM>/edge/<PR>
         run: |
           set -uo pipefail
-          TRACK="${{ steps.meta.outputs.track }}"
+          TRACK="${{ needs.meta.outputs.track }}"
           PR="${{ github.event.pull_request.number }}"
           CHAN="$TRACK/edge/$PR"
-          IFS=',' read -ra WANT <<< "${{ steps.meta.outputs.archs }}"
-          uploaded=(); missing=()
-          for arch in "${WANT[@]}"; do
-            # Matches name_version_arch.snap (snapcraft 8.14+ / core26) — '*' also tolerates name_arch.snap.
-            f="$(ls -1 "${SNAP_NAME}"*"${arch}".snap 2>/dev/null | head -n1 || true)"
-            if [ -z "$f" ]; then echo "missing snap for $arch"; missing+=("$arch"); continue; fi
-            echo "Uploading $f -> $CHAN"
-            # Retry the store upload: it can drop mid-transfer ("Connection aborted /
-            # RemoteDisconnected") on an otherwise-valid snap — a transient blip must not
-            # fail the build. Bounded, so a genuine rejection still fails. See retry.test.sh.
-            if .github/scripts/retry.sh 3 15 -- snapcraft upload "$f" --release="$CHAN"; then uploaded+=("$arch"); else echo "upload failed for $arch"; missing+=("$arch"); fi
-          done
-          {
-            echo "channel=$CHAN"
-            echo "missing=${missing[*]:-}"
-          } >> "$GITHUB_OUTPUT"
-          {
-            echo "comment<<EOF"
-            if [ "${#uploaded[@]}" -gt 0 ]; then
-              printf '✅ Snap for this PR published to `%s`\n\n' "$CHAN"
-              printf '```bash\nsudo snap install %s --channel=%s   # or: sudo snap refresh %s --channel=%s\n```\n\n' "$SNAP_NAME" "$CHAN" "$SNAP_NAME" "$CHAN"
-              printf 'Built: %s\n' "${uploaded[*]}"
-            else
-              printf '❌ No architectures were published for this PR.\n'
-            fi
-            if [ "${#missing[@]}" -gt 0 ]; then printf '\n⚠️ Failed/missing arch(es): %s\n' "${missing[*]}"; fi
-            echo "EOF"
-          } >> "$GITHUB_OUTPUT"
+          ARCH="${{ matrix.arch }}"
+          f="$(ls -1 "${SNAP_NAME}"*"${ARCH}".snap 2>/dev/null | head -n1 || true)"
+          # FAIL (not no-op) when the artifact is missing, so "Re-run failed jobs"
+          # re-pairs a rebuilt arch with its upload instead of silently skipping it.
+          if [ -z "$f" ]; then
+            echo "::error::No snap artifact for ${ARCH} — its build did not succeed."
+            exit 1
+          fi
+          echo "Uploading $f -> $CHAN"
+          .github/scripts/retry.sh 3 15 -- snapcraft upload "$f" --release="$CHAN"
+      - name: Mark published
+        run: |
+          mkdir -p out && : > "out/uploaded-${{ matrix.arch }}"
+      - name: Upload published marker
+        uses: actions/upload-artifact@v4
+        with:
+          name: uploaded-${{ matrix.arch }}
+          path: out/uploaded-${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
 
+  report:
+    needs: [meta, build, ensure-track, upload]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download published markers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: uploaded-*
+          path: markers
+          merge-multiple: true
+        continue-on-error: true
+      - name: Download build logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: buildlog-*
+          path: buildlogs
+          merge-multiple: true
+        continue-on-error: true
+      - name: Render comment + completeness
+        id: r
+        run: |
+          set -uo pipefail
+          TRACK="${{ needs.meta.outputs.track }}"
+          PR="${{ github.event.pull_request.number }}"
+          CHAN="$TRACK/edge/$PR"
+          WANTED="${{ needs.meta.outputs.archs_csv }}"
+          PUBLISHED="$(ls markers/ 2>/dev/null | sed -n 's/^uploaded-//p' | paste -sd, - || true)"
+          BODY="${RUNNER_TEMP}/comment.md"
+          SNAP_NAME="$SNAP_NAME" .github/scripts/pr-comment.sh "$CHAN" "$WANTED" "$PUBLISHED" > "$BODY"
+          # Fold the build log into the comment only when nothing was published.
+          if [ -z "$PUBLISHED" ] && ls buildlogs/* >/dev/null 2>&1; then
+            {
+              echo
+              echo '<details><summary>snapcraft log (last 50 KB)</summary>'
+              echo
+              echo '```text'
+              cat buildlogs/*
+              echo '```'
+              echo
+              echo '</details>'
+            } >> "$BODY"
+          fi
+          echo "body=$BODY" >> "$GITHUB_OUTPUT"
+          w="$(printf '%s' "$WANTED"    | tr ',' '\n' | sed '/^$/d' | sort -u)"
+          p="$(printf '%s' "$PUBLISHED" | tr ',' '\n' | sed '/^$/d' | sort -u)"
+          if [ "$w" = "$p" ]; then echo "complete=yes" >> "$GITHUB_OUTPUT"; else echo "complete=no" >> "$GITHUB_OUTPUT"; fi
       - name: Sticky PR comment
-        if: ${{ always() && github.event_name == 'pull_request' }}
         uses: actions/github-script@v9
         env:
-          BODY: ${{ steps.release.outputs.comment }}
-          BUILT: ${{ steps.build.outputs.snaps }}
-          SCLOG_FILE: ${{ steps.sclog.outputs.tail_file }}
+          BODY: ${{ steps.r.outputs.body }}
         with:
           script: |
             const fs = require('fs');
             const marker = '<!-- pr-build-snap -->';
-            const failed = (!process.env.BUILT || process.env.BUILT === '0' || !process.env.BODY);
-            let text = failed
-              ? '❌ Build produced no snaps (or a preceding step failed). Check the Action logs.'
-              : process.env.BODY;
-            // On failure, fold the captured snapcraft log (last 50 KB) into the comment.
-            if (failed && process.env.SCLOG_FILE && fs.existsSync(process.env.SCLOG_FILE)) {
-              const log = fs.readFileSync(process.env.SCLOG_FILE, 'utf8');
-              text += `\n\n<details>\n<summary>snapcraft log (last 50 KB)</summary>\n\n\`\`\`text\n${log}\n\`\`\`\n\n</details>`;
-            }
+            const text = fs.readFileSync(process.env.BODY, 'utf8');
             const body = `${marker}\n${text}`;
             const { owner, repo } = context.repo;
             const issue_number = context.payload.pull_request.number;
-            const issuesApi = (github.rest && github.rest.issues) ? github.rest.issues : github.issues;
-            const { data: comments } = await issuesApi.listComments({ owner, repo, issue_number, per_page: 100 });
+            const api = github.rest.issues;
+            const { data: comments } = await api.listComments({ owner, repo, issue_number, per_page: 100 });
             const existing = comments.find(c => c.body && c.body.includes(marker));
-            if (existing) {
-              await issuesApi.updateComment({ owner, repo, comment_id: existing.id, body });
-            } else {
-              await issuesApi.createComment({ owner, repo, issue_number, body });
-            }
-
-      - name: Fail if build/upload incomplete
-        if: ${{ steps.build.outputs.snaps == '0' || steps.release.outputs.missing != '' }}
+            if (existing) await api.updateComment({ owner, repo, comment_id: existing.id, body });
+            else await api.createComment({ owner, repo, issue_number, body });
+      - name: Fail if any wanted arch is unpublished
+        if: ${{ steps.r.outputs.complete != 'yes' }}
         run: |
-          echo "::error::Incomplete: snaps=${{ steps.build.outputs.snaps }} missing=[${{ steps.release.outputs.missing }}]"
+          echo "::error::Incomplete publish: wanted=[${{ needs.meta.outputs.archs_csv }}]"
           exit 1

--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -148,7 +148,7 @@ jobs:
         continue-on-error: true   # missing => this arch's build failed; handled below
       - name: Upload to v<MM>/edge/<PR>
         run: |
-          set -uo pipefail
+          set -euo pipefail
           TRACK="${{ needs.meta.outputs.track }}"
           PR="${{ github.event.pull_request.number }}"
           CHAN="$TRACK/edge/$PR"
@@ -163,9 +163,11 @@ jobs:
           echo "Uploading $f -> $CHAN"
           .github/scripts/retry.sh 3 15 -- snapcraft upload "$f" --release="$CHAN"
       - name: Mark published
+        if: ${{ success() }}
         run: |
           mkdir -p out && : > "out/uploaded-${{ matrix.arch }}"
       - name: Upload published marker
+        if: ${{ success() }}
         uses: actions/upload-artifact@v4
         with:
           name: uploaded-${{ matrix.arch }}
@@ -196,7 +198,7 @@ jobs:
       - name: Render comment + completeness
         id: r
         run: |
-          set -uo pipefail
+          set -euo pipefail
           TRACK="${{ needs.meta.outputs.track }}"
           PR="${{ github.event.pull_request.number }}"
           CHAN="$TRACK/edge/$PR"
@@ -204,6 +206,15 @@ jobs:
           PUBLISHED="$(ls markers/ 2>/dev/null | sed -n 's/^uploaded-//p' | paste -sd, - || true)"
           BODY="${RUNNER_TEMP}/comment.md"
           SNAP_NAME="$SNAP_NAME" .github/scripts/pr-comment.sh "$CHAN" "$WANTED" "$PUBLISHED" > "$BODY"
+          # When the track couldn't be ensured (e.g. expired SNAPCRAFT_SESSION_COOKIE),
+          # uploads are skipped even though builds may have succeeded — say so explicitly
+          # rather than letting the comment read like a build failure.
+          if [ "${{ needs.ensure-track.result }}" != "success" ]; then
+            {
+              echo
+              echo '⚠️ Release was blocked: the version track could not be ensured (see the **ensure-track** job — e.g. an expired `SNAPCRAFT_SESSION_COOKIE`). Builds may have succeeded; fix the cause and use "Re-run failed jobs".'
+            } >> "$BODY"
+          fi
           # Fold the build log into the comment only when nothing was published.
           if [ -z "$PUBLISHED" ] && ls buildlogs/* >/dev/null 2>&1; then
             {
@@ -221,6 +232,8 @@ jobs:
           w="$(printf '%s' "$WANTED"    | tr ',' '\n' | sed '/^$/d' | sort -u)"
           p="$(printf '%s' "$PUBLISHED" | tr ',' '\n' | sed '/^$/d' | sort -u)"
           if [ "$w" = "$p" ]; then echo "complete=yes" >> "$GITHUB_OUTPUT"; else echo "complete=no" >> "$GITHUB_OUTPUT"; fi
+          missing="$(comm -23 <(printf '%s\n' "$w") <(printf '%s\n' "$p") | paste -sd, - || true)"
+          echo "missing=$missing" >> "$GITHUB_OUTPUT"
       - name: Sticky PR comment
         uses: actions/github-script@v9
         env:
@@ -241,5 +254,5 @@ jobs:
       - name: Fail if any wanted arch is unpublished
         if: ${{ steps.r.outputs.complete != 'yes' }}
         run: |
-          echo "::error::Incomplete publish: wanted=[${{ needs.meta.outputs.archs_csv }}]"
+          echo "::error::Incomplete publish: missing=[${{ steps.r.outputs.missing }}] wanted=[${{ needs.meta.outputs.archs_csv }}]"
           exit 1

--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -77,12 +77,12 @@ jobs:
           # 1) Major bump: move previous major's final to latest/stable BEFORE candidate is overwritten.
           if [ "$("$SR" needs-stable-bump "$V" "$CAND")" = "yes" ]; then
             echo ">> major bump: latest/candidate -> latest/stable"
-            snapcraft promote "$SNAP" --from-channel latest/candidate --to-channel latest/stable --yes
+            .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel latest/candidate --to-channel latest/stable --yes
           fi
 
           # 2) The version track's own stable line (always; safe for backports).
           echo ">> $BRANCH -> $TRACK/stable"
-          snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$TRACK/stable" --yes
+          .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$TRACK/stable" --yes
 
           # 3) Shared latest/* — promote each channel only if $V is >= that channel's OWN
           #    current version, so a backport can never downgrade a channel already ahead.
@@ -91,7 +91,7 @@ jobs:
           if [ -n "$TARGETS" ]; then
             for ch in $TARGETS; do
               echo ">> $BRANCH -> $ch"
-              snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$ch" --yes
+              .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$ch" --yes
             done
           else
             echo ">> backport ($V; candidate=${CAND:-<none>} edge=${EDGE:-<none>}): leaving latest/* unchanged"
@@ -99,14 +99,14 @@ jobs:
 
           # 4) Close the PR branch (auto-expires anyway; this is tidy-up).
           echo ">> closing $BRANCH"
-          snapcraft close "$SNAP" "$BRANCH" --yes || echo "close failed (already gone?); ignoring"
+          .github/scripts/retry.sh 3 15 -- snapcraft close "$SNAP" "$BRANCH" --yes || echo "close failed (already gone?); ignoring"
 
           # 5) Default track follows the merged line; never regresses or jumps to stray tracks.
           CAND_TRACK=""
           if [ -n "$CAND" ]; then CAND_TRACK="$("$SR" version-to-track "$CAND")"; fi
           if [ "$TRACK" != "$CAND_TRACK" ] && [ "$("$SR" is-at-least "$TRACK" "$CAND_TRACK")" = "yes" ]; then
             echo ">> set default track -> $TRACK"
-            snapcraft set-default-track "$SNAP" "$TRACK"
+            .github/scripts/retry.sh 3 15 -- snapcraft set-default-track "$SNAP" "$TRACK"
           else
             echo ">> default track unchanged (line=${CAND_TRACK:-<none>})"
           fi

--- a/docs/superpowers/plans/2026-06-22-ci-build-release-split.md
+++ b/docs/superpowers/plans/2026-06-22-ci-build-release-split.md
@@ -1,0 +1,557 @@
+# CI build/release split — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Restructure `pr-build-snap.yml` so a failed release retries without rebuilding, with per-arch build/upload, and retry-harden `release-on-merge.yml`.
+
+**Architecture:** Five jobs — `meta` → (`ensure-track` ∥ `build[arch]`) → `upload[arch]` → `report`. Snaps move between `build` and `upload` as per-arch artifacts; `report` derives the published set from `uploaded-<arch>` marker artifacts. The only new, unit-testable code is a pure comment renderer (`pr-comment.sh`); the workflows are verified with `actionlint` + a real PR run.
+
+**Tech Stack:** GitHub Actions, bash, `yq`, `snapcraft`, existing helpers (`remote-build.sh`, `snap-create-track.sh`, `retry.sh`, `snap-release.sh`).
+
+Spec: `docs/superpowers/specs/2026-06-22-ci-build-release-split-design.md`.
+
+---
+
+## File structure
+
+- **Create** `.github/scripts/pr-comment.sh` — pure renderer: `(channel, wanted-csv, published-csv) → markdown`. One responsibility: the install/availability comment body.
+- **Create** `.github/scripts/pr-comment.test.sh` — unit tests (auto-run by `helper-tests.yml`).
+- **Rewrite** `.github/workflows/pr-build-snap.yml` — single job → five jobs.
+- **Modify** `.github/workflows/release-on-merge.yml` — wrap the three store mutations in `retry.sh`.
+
+---
+
+## Task 1: Pure PR-comment renderer (`pr-comment.sh`)
+
+**Files:**
+- Create: `.github/scripts/pr-comment.sh`
+- Test: `.github/scripts/pr-comment.test.sh`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `.github/scripts/pr-comment.test.sh`:
+
+```bash
+#!/usr/bin/env bash
+# Unit tests for pr-comment.sh. Pure: no network. Asserts the three renderings.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PC="$HERE/pr-comment.sh"
+export SNAP_NAME=zwave-js-ui
+fail=0
+has()  { if printf '%s' "$2" | grep -qF -- "$3"; then printf 'ok   - %s\n' "$1"; else printf 'FAIL - %s\n       missing: [%s]\n       in:      [%s]\n' "$1" "$3" "$2"; fail=1; fi; }
+hasnt(){ if printf '%s' "$2" | grep -qF -- "$3"; then printf 'FAIL - %s\n       unexpected: [%s]\n' "$1" "$3"; fail=1; else printf 'ok   - %s\n' "$1"; fi; }
+
+CH="v11.21/edge/210"
+
+all="$("$PC" "$CH" "amd64,arm64,armhf" "amd64,arm64,armhf")"
+has   "all: success header"      "$all" "✅ Published to \`$CH\`"
+has   "all: lists every arch"    "$all" "Architectures: amd64, arm64, armhf"
+has   "all: install command"     "$all" "sudo snap install zwave-js-ui --channel=$CH"
+has   "all: auto-selects note"   "$all" "auto-selects your arch"
+hasnt "all: no failed line"      "$all" "❌ Failed:"
+
+part="$("$PC" "$CH" "amd64,arm64,armhf" "amd64,arm64")"
+has   "partial: warn header"     "$part" "⚠️ Partial publish to \`$CH\` — 2 of 3"
+has   "partial: available list"  "$part" "Available for: amd64, arm64"
+has   "partial: works-on note"   "$part" "works on: amd64, arm64"
+has   "partial: failed arch"     "$part" "❌ Failed: armhf"
+hasnt "partial: armhf not avail" "$part" "Available for: amd64, arm64, armhf"
+
+none="$("$PC" "$CH" "amd64,arm64,armhf" "")"
+has   "none: nothing published"  "$none" "❌ No architectures were published"
+
+[ "$fail" -eq 0 ] && echo "All pr-comment tests passed." || echo "Some pr-comment tests FAILED."
+exit "$fail"
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `bash .github/scripts/pr-comment.test.sh`
+Expected: FAIL — `pr-comment.sh` does not exist yet (`bash: .../pr-comment.sh: No such file or directory`).
+
+- [ ] **Step 3: Write the renderer**
+
+Create `.github/scripts/pr-comment.sh`:
+
+```bash
+#!/usr/bin/env bash
+# pr-comment.sh — render the sticky PR-build comment body for pr-build-snap.yml.
+# Pure: args in, markdown on stdout, no network. Unit-tested by pr-comment.test.sh.
+#
+# Usage:  pr-comment.sh <channel> <wanted-csv> <published-csv>
+#   <wanted-csv>    archs the build targeted, e.g. "amd64,arm64,armhf"
+#   <published-csv> archs that reached the channel (may be empty)
+# Env:    SNAP_NAME (default zwave-js-ui)
+set -euo pipefail
+
+chan="${1:?usage: pr-comment.sh <channel> <wanted-csv> <published-csv>}"
+wanted="${2:-}"
+published="${3:-}"
+snap="${SNAP_NAME:-zwave-js-ui}"
+
+# csv -> sorted-unique newline list (empties dropped)
+to_lines() { printf '%s' "${1:-}" | tr ',' '\n' | sed '/^$/d' | sort -u; }
+w="$(to_lines "$wanted")"
+p="$(to_lines "$published")"
+count() { printf '%s\n' "${1}" | sed '/^$/d' | wc -l | tr -d ' '; }
+nw="$(count "$w")"
+np="$(count "$p")"
+
+avail="$(printf '%s' "$p" | paste -sd', ' -)"
+failed="$(comm -23 <(printf '%s\n' "$w" | sed '/^$/d') <(printf '%s\n' "$p" | sed '/^$/d') | paste -sd', ' -)"
+
+if [ "$np" -eq 0 ]; then
+    printf '❌ No architectures were published for this PR.\n'
+    exit 0
+fi
+
+if [ -z "$failed" ]; then
+    printf '✅ Published to `%s` — available to install & test:\n\n' "$chan"
+    printf '  Architectures: %s\n' "$avail"
+    note="auto-selects your arch"
+else
+    printf '⚠️ Partial publish to `%s` — %s of %s architectures.\n\n' "$chan" "$np" "$nw"
+    printf '  Available for: %s\n' "$avail"
+    note="works on: $avail"
+fi
+printf '  sudo snap install %s --channel=%s      # %s\n' "$snap" "$chan" "$note"
+printf '  # or: sudo snap refresh %s --channel=%s\n' "$snap" "$chan"
+if [ -n "$failed" ]; then
+    printf '\n  ❌ Failed: %s — use "Re-run failed jobs" to retry just that arch (no rebuild of the published archs).\n' "$failed"
+fi
+```
+
+- [ ] **Step 4: Make it executable**
+
+Run: `chmod 755 .github/scripts/pr-comment.sh`
+
+- [ ] **Step 5: Run the test to verify it passes**
+
+Run: `bash .github/scripts/pr-comment.test.sh`
+Expected: PASS — `All pr-comment tests passed.`
+
+- [ ] **Step 6: Shellcheck (matches helper-tests.yml gate)**
+
+Run: `shellcheck .github/scripts/pr-comment.sh .github/scripts/pr-comment.test.sh`
+Expected: no output (clean).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add .github/scripts/pr-comment.sh .github/scripts/pr-comment.test.sh
+git commit -m "feat(ci): pure PR-build comment renderer (per-arch availability)"
+```
+
+---
+
+## Task 2: Rewrite `pr-build-snap.yml` into five jobs
+
+**Files:**
+- Modify (full rewrite): `.github/workflows/pr-build-snap.yml`
+
+- [ ] **Step 1: Replace the file with the five-job workflow**
+
+Write `.github/workflows/pr-build-snap.yml`:
+
+```yaml
+name: PR Build Snap
+
+on:
+  pull_request:
+    branches: [main]
+    types: [opened, synchronize, reopened]
+    # Only the snap recipe and its bundled inputs affect the built artifact, so
+    # build + publish ONLY when those change. Docs/config edits must not mint a
+    # store revision. requirements-duplicity.txt IS a build input (pip-installed).
+    paths:
+      - 'snap/**'
+      - 'src/**'
+      - 'requirements-duplicity.txt'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-build-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+env:
+  SNAP_NAME: zwave-js-ui
+
+jobs:
+  meta:
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{ steps.meta.outputs.version }}
+      track: ${{ steps.meta.outputs.track }}
+      archs: ${{ steps.meta.outputs.archs }}
+      archs_csv: ${{ steps.meta.outputs.archs_csv }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Resolve version / track / archs
+        id: meta
+        run: |
+          set -euo pipefail
+          V="$(yq '.version' snap/snapcraft.yaml)"
+          TRACK="$(.github/scripts/snap-release.sh version-to-track "$V")"
+          ARCHS_JSON="$(yq -o=json -I=0 '.platforms | keys' snap/snapcraft.yaml)"
+          ARCHS_CSV="$(yq '.platforms | keys | join(",")' snap/snapcraft.yaml)"
+          {
+            echo "version=$V"
+            echo "track=$TRACK"
+            echo "archs=$ARCHS_JSON"
+            echo "archs_csv=$ARCHS_CSV"
+          } >> "$GITHUB_OUTPUT"
+
+  # Runs in parallel with the builds: it only needs the track NAME, so a failed
+  # build never blocks or skips it. Idempotent (the script checks existence first).
+  ensure-track:
+    needs: meta
+    if: ${{ github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+      SNAPCRAFT_SESSION_COOKIE: ${{ secrets.SNAPCRAFT_SESSION_COOKIE }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Ensure version track exists
+        run: |
+          set -euo pipefail
+          TRACK="${{ needs.meta.outputs.track }}"
+          # Listing tracks uses the macaroon; skip create if it already exists.
+          if snapcraft tracks "$SNAP_NAME" | awk 'NR>1{print $1}' | grep -qx "$TRACK"; then
+            echo "Track $TRACK already exists."
+            exit 0
+          fi
+          bash .github/scripts/snap-create-track.sh "$SNAP_NAME" "$TRACK"
+
+  build:
+    needs: meta
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false           # a dead arch must not cancel its siblings
+      matrix:
+        arch: ${{ fromJSON(needs.meta.outputs.archs) }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0         # snapcraft remote-build refuses shallow clones
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Configure Launchpad credentials
+        run: |
+          set -euo pipefail
+          mkdir -p ~/.local/share/snapcraft
+          printf '%s\n' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
+      - name: Remote-build ${{ matrix.arch }}
+        id: build
+        run: .github/scripts/remote-build.sh "${{ matrix.arch }}"
+      - name: Upload snap artifact
+        if: ${{ steps.build.outputs.snaps != '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: ${{ env.SNAP_NAME }}*${{ matrix.arch }}.snap
+          retention-days: 1
+          if-no-files-found: error
+      - name: Capture snapcraft log on failure
+        if: ${{ always() && steps.build.outputs.snaps == '0' }}
+        run: |
+          shopt -s nullglob
+          logs=( ~/.local/state/snapcraft/log/*.log ~/.cache/snapcraft/log/*.log )
+          out="${RUNNER_TEMP}/buildlog-${{ matrix.arch }}.txt"; : > "$out"
+          if [ ${#logs[@]} -eq 0 ]; then
+            echo "(no snapcraft log files found for ${{ matrix.arch }})" >> "$out"
+          else
+            for f in "${logs[@]}"; do { echo "===== $f ====="; cat "$f"; } >> "$out"; done
+          fi
+          tail -c 50000 "$out" > "$out.cut" && mv "$out.cut" "$out"
+          echo "BUILDLOG=$out" >> "$GITHUB_ENV"
+      - name: Upload snapcraft log artifact
+        if: ${{ always() && steps.build.outputs.snaps == '0' }}
+        uses: actions/upload-artifact@v4
+        with:
+          name: buildlog-${{ matrix.arch }}
+          path: ${{ env.BUILDLOG }}
+          retention-days: 1
+          if-no-files-found: ignore
+
+  upload:
+    needs: [meta, build, ensure-track]
+    # Run even though `build` reports failure from a sibling arch (!cancelled),
+    # but only once the track exists.
+    if: ${{ !cancelled() && needs.ensure-track.result == 'success' }}
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        arch: ${{ fromJSON(needs.meta.outputs.archs) }}
+    env:
+      SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAPCRAFT_STORE_CREDENTIALS }}
+    steps:
+      - uses: actions/checkout@v7
+      - name: Install snapcraft
+        run: sudo snap install snapcraft --classic
+      - name: Download snap artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: snap-${{ matrix.arch }}
+          path: .
+        continue-on-error: true   # missing => this arch's build failed; handled below
+      - name: Upload to v<MM>/edge/<PR>
+        run: |
+          set -uo pipefail
+          TRACK="${{ needs.meta.outputs.track }}"
+          PR="${{ github.event.pull_request.number }}"
+          CHAN="$TRACK/edge/$PR"
+          ARCH="${{ matrix.arch }}"
+          f="$(ls -1 "${SNAP_NAME}"*"${ARCH}".snap 2>/dev/null | head -n1 || true)"
+          # FAIL (not no-op) when the artifact is missing, so "Re-run failed jobs"
+          # re-pairs a rebuilt arch with its upload instead of silently skipping it.
+          if [ -z "$f" ]; then
+            echo "::error::No snap artifact for ${ARCH} — its build did not succeed."
+            exit 1
+          fi
+          echo "Uploading $f -> $CHAN"
+          .github/scripts/retry.sh 3 15 -- snapcraft upload "$f" --release="$CHAN"
+      - name: Mark published
+        run: mkdir -p out && : > "out/uploaded-${{ matrix.arch }}"
+      - name: Upload published marker
+        uses: actions/upload-artifact@v4
+        with:
+          name: uploaded-${{ matrix.arch }}
+          path: out/uploaded-${{ matrix.arch }}
+          retention-days: 1
+          if-no-files-found: error
+
+  report:
+    needs: [meta, build, ensure-track, upload]
+    if: ${{ always() && github.event_name == 'pull_request' }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: Download published markers
+        uses: actions/download-artifact@v4
+        with:
+          pattern: uploaded-*
+          path: markers
+          merge-multiple: true
+        continue-on-error: true
+      - name: Download build logs
+        uses: actions/download-artifact@v4
+        with:
+          pattern: buildlog-*
+          path: buildlogs
+          merge-multiple: true
+        continue-on-error: true
+      - name: Render comment + completeness
+        id: r
+        run: |
+          set -uo pipefail
+          TRACK="${{ needs.meta.outputs.track }}"
+          PR="${{ github.event.pull_request.number }}"
+          CHAN="$TRACK/edge/$PR"
+          WANTED="${{ needs.meta.outputs.archs_csv }}"
+          PUBLISHED="$(ls markers/ 2>/dev/null | sed -n 's/^uploaded-//p' | paste -sd, - || true)"
+          BODY="${RUNNER_TEMP}/comment.md"
+          SNAP_NAME="$SNAP_NAME" .github/scripts/pr-comment.sh "$CHAN" "$WANTED" "$PUBLISHED" > "$BODY"
+          # Fold the build log into the comment only when nothing was published.
+          if [ -z "$PUBLISHED" ] && ls buildlogs/* >/dev/null 2>&1; then
+            {
+              echo
+              echo '<details><summary>snapcraft log (last 50 KB)</summary>'
+              echo
+              echo '```text'
+              cat buildlogs/*
+              echo '```'
+              echo
+              echo '</details>'
+            } >> "$BODY"
+          fi
+          echo "body=$BODY" >> "$GITHUB_OUTPUT"
+          w="$(printf '%s' "$WANTED"    | tr ',' '\n' | sed '/^$/d' | sort -u)"
+          p="$(printf '%s' "$PUBLISHED" | tr ',' '\n' | sed '/^$/d' | sort -u)"
+          if [ "$w" = "$p" ]; then echo "complete=yes" >> "$GITHUB_OUTPUT"; else echo "complete=no" >> "$GITHUB_OUTPUT"; fi
+      - name: Sticky PR comment
+        uses: actions/github-script@v9
+        env:
+          BODY: ${{ steps.r.outputs.body }}
+        with:
+          script: |
+            const fs = require('fs');
+            const marker = '<!-- pr-build-snap -->';
+            const text = fs.readFileSync(process.env.BODY, 'utf8');
+            const body = `${marker}\n${text}`;
+            const { owner, repo } = context.repo;
+            const issue_number = context.payload.pull_request.number;
+            const api = github.rest.issues;
+            const { data: comments } = await api.listComments({ owner, repo, issue_number, per_page: 100 });
+            const existing = comments.find(c => c.body && c.body.includes(marker));
+            if (existing) await api.updateComment({ owner, repo, comment_id: existing.id, body });
+            else await api.createComment({ owner, repo, issue_number, body });
+      - name: Fail if any wanted arch is unpublished
+        if: ${{ steps.r.outputs.complete != 'yes' }}
+        run: |
+          echo "::error::Incomplete publish: wanted=[${{ needs.meta.outputs.archs_csv }}]"
+          exit 1
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run: `python3 -c "import yaml,sys; yaml.safe_load(open('.github/workflows/pr-build-snap.yml')); print('yaml ok')"`
+Expected: `yaml ok`
+
+- [ ] **Step 3: Lint with actionlint (the repo's chosen linter — note `.gitignore` ships the binary)**
+
+Run: `command -v actionlint && actionlint .github/workflows/pr-build-snap.yml || echo "actionlint not installed — skipping (CI/PR run will catch issues)"`
+Expected: no findings (or the skip notice if the binary isn't present locally).
+
+- [ ] **Step 4: Confirm the job graph + key gates with a grep sanity check**
+
+Run:
+```bash
+grep -nE 'fail-fast: false|fromJSON\(needs.meta.outputs.archs\)|needs.ensure-track.result == .success.|!cancelled\(\)|always\(\)' .github/workflows/pr-build-snap.yml
+```
+Expected: matches for both matrices (`fail-fast: false` ×2, `fromJSON` ×2), the upload gate (`!cancelled()` + `ensure-track.result == 'success'`), and `always()` on report.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/pr-build-snap.yml
+git commit -m "ci(build): split pr-build-snap into meta/ensure-track/build/upload/report (per-arch, selective re-run)"
+```
+
+---
+
+## Task 3: Retry-harden `release-on-merge.yml`
+
+**Files:**
+- Modify: `.github/workflows/release-on-merge.yml` (the `Promote PR revisions to release channels` step)
+
+- [ ] **Step 1: Wrap each store mutation in `retry.sh`**
+
+In `.github/workflows/release-on-merge.yml`, inside the `Promote PR revisions to release channels` step, prefix each `snapcraft promote` / `snapcraft close` / `snapcraft set-default-track` invocation with `.github/scripts/retry.sh 3 15 --`. Apply these exact replacements:
+
+Replace:
+```bash
+            snapcraft promote "$SNAP" --from-channel latest/candidate --to-channel latest/stable --yes
+```
+with:
+```bash
+            .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel latest/candidate --to-channel latest/stable --yes
+```
+
+Replace:
+```bash
+          snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$TRACK/stable" --yes
+```
+with:
+```bash
+          .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel "$TRACK/stable" --yes
+```
+
+Replace:
+```bash
+            snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/candidate --yes
+            snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/edge --yes
+```
+with:
+```bash
+            .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/candidate --yes
+            .github/scripts/retry.sh 3 15 -- snapcraft promote "$SNAP" --from-channel "$BRANCH" --to-channel latest/edge --yes
+```
+
+Replace:
+```bash
+          snapcraft close "$SNAP" "$BRANCH" --yes || echo "close failed (already gone?); ignoring"
+```
+with:
+```bash
+          .github/scripts/retry.sh 3 15 -- snapcraft close "$SNAP" "$BRANCH" --yes || echo "close failed (already gone?); ignoring"
+```
+
+Replace:
+```bash
+            snapcraft set-default-track "$SNAP" "$TRACK"
+```
+with:
+```bash
+            .github/scripts/retry.sh 3 15 -- snapcraft set-default-track "$SNAP" "$TRACK"
+```
+
+- [ ] **Step 2: Validate the YAML parses**
+
+Run: `python3 -c "import yaml; yaml.safe_load(open('.github/workflows/release-on-merge.yml')); print('yaml ok')"`
+Expected: `yaml ok`
+
+- [ ] **Step 3: Confirm every mutation is wrapped (and none missed)**
+
+Run:
+```bash
+grep -nE 'snapcraft (promote|close|set-default-track)' .github/workflows/release-on-merge.yml
+```
+Expected: every matching line is prefixed with `.github/scripts/retry.sh 3 15 --` (5 invocations total).
+
+- [ ] **Step 4: actionlint (if present)**
+
+Run: `command -v actionlint && actionlint .github/workflows/release-on-merge.yml || echo "actionlint not installed — skipping"`
+Expected: no findings (or skip notice).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/release-on-merge.yml
+git commit -m "ci(release): retry-harden merge promotions (transient 401/disconnect)"
+```
+
+---
+
+## Task 4: Final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the full helper test suite (the helper-tests.yml gate)**
+
+Run:
+```bash
+shellcheck .github/scripts/*.sh && for t in .github/scripts/*.test.sh; do echo "== $t"; bash "$t" || exit 1; done
+```
+Expected: shellcheck clean; every `*.test.sh` ends with its "All … tests passed." line and exit 0 (includes the new `pr-comment.test.sh`).
+
+- [ ] **Step 2: Parse all workflows**
+
+Run:
+```bash
+for f in .github/workflows/*.yml; do python3 -c "import yaml,sys; yaml.safe_load(open('$f')); print('ok', '$f')"; done
+```
+Expected: `ok` for every workflow file.
+
+- [ ] **Step 3: Push the branch and open a PR (integration test is the real run)**
+
+The workflow's true behavior can only be verified on GitHub. Push and open the PR, then check on the PR's Actions run:
+
+```bash
+git push -u origin feat/ci-build-release-split
+gh pr create --base main --head feat/ci-build-release-split \
+  --title "ci: split build/release for selective re-run (per-arch)" \
+  --body-file docs/superpowers/specs/2026-06-22-ci-build-release-split-design.md
+```
+
+- [ ] **Step 4: Acceptance checks on the PR run** (from the spec's Testing section)
+
+Confirm on the Actions run:
+1. **Clean PR:** `meta` → `ensure-track` runs in parallel with `build` (3 arch jobs) → `upload` (3 arch jobs) → `report`; the sticky comment lists all archs; the overall check is green.
+2. **Selective re-run (release):** if `ensure-track` ever fails (e.g. stale `SNAPCRAFT_SESSION_COOKIE`), the `build` jobs stay green; clicking **Re-run failed jobs** reruns only `ensure-track` + `upload` + `report` — **no rebuild**.
+3. **Selective re-run (arch):** if one `build-<arch>` fails, the others publish, the comment notifies + lists the available archs, and **Re-run failed jobs** rebuilds + uploads only the failed arch (no new revisions for the already-published archs).
+
+---
+
+## Notes
+
+- `SNAPCRAFT_SESSION_COOKIE` is currently expired (it broke PR #210). That refresh is an operational prerequisite, **out of scope** for this code change — but acceptance check #2 above is exactly the scenario it causes, so this PR is the natural place to confirm the selective re-run once the secret is refreshed.
+- If per-arch parallel `remote-build` overloads Launchpad (the account has previously hit a scanner wedge), the fallback in the spec is a single `build` job that builds all archs and emits per-arch artifacts — keeping per-arch *upload* while dropping per-arch *build*. Decide based on acceptance check #1.

--- a/docs/superpowers/specs/2026-06-22-ci-build-release-split-design.md
+++ b/docs/superpowers/specs/2026-06-22-ci-build-release-split-design.md
@@ -1,0 +1,151 @@
+# CI build/release split — design
+
+**Status:** approved (brainstorm) — 2026-06-22
+**Scope:** `.github/workflows/pr-build-snap.yml` (restructure) and `.github/workflows/release-on-merge.yml` (retry-hardening). Helper scripts unchanged.
+
+## Goal
+
+Make a failed *release* (store upload / track creation) retryable **without** re-running the ~39-minute Launchpad build, and make each architecture independently buildable, publishable, and re-runnable.
+
+## Motivation
+
+`pr-build-snap.yml` is today a single `build-and-release` job: the expensive `remote-build` step and the `ensure-track` + `upload` steps share one job. GitHub's "Re-run failed jobs" works at job granularity, so any release-side failure forces a full rebuild.
+
+This is not hypothetical. PR #210's run failed after a **successful 39-minute build** at `Ensure version track exists`:
+
+```
+create-track zwave-js-ui/v11.21: HTTP 401
+create-track unauthorized — refresh SNAPCRAFT_SESSION_COOKIE
+```
+
+The build was fine; only the storefront session cookie had expired. Re-running re-does the whole build. The split below turns that into a ~10-second re-run of one tiny job.
+
+## Architecture
+
+Split `pr-build-snap.yml` into five jobs. `build` and `upload` are per-arch matrices; `ensure-track` runs in parallel with the builds (it needs only the track name).
+
+```
+        ┌─► ensure-track ─────────────────────────────┐
+meta ───┤                                              ├─► report (always)
+        └─► build(arch)[matrix] ──► upload(arch)[matrix] ┘
+                                    (needs build + ensure-track)
+```
+
+| Job | `needs` | Matrix | Purpose |
+|---|---|---|---|
+| `meta` | — | — | Resolve `version`, `track`, `archs` (JSON array) from `snap/snapcraft.yaml`. |
+| `ensure-track` | `meta` | — | Create the `v<MM>` track once if missing (session cookie). Idempotent. |
+| `build` | `meta` | `arch` | `remote-build.sh <arch>`; on success upload artifact `snap-<arch>`. |
+| `upload` | `build`, `ensure-track` | `arch` | Download `snap-<arch>`, `snapcraft upload --release=<chan>` via `retry.sh`; on success emit marker artifact `uploaded-<arch>`. |
+| `report` | `build`, `ensure-track`, `upload` | — | Aggregate published archs from `uploaded-*`; post sticky PR comment; fail-gate. |
+
+`meta` exposes `archs` as a JSON array so `build`/`upload` set `strategy.matrix.arch: ${{ fromJSON(needs.meta.outputs.archs) }}`.
+
+### Why these boundaries
+
+Each job is one **distinct failure cause / credential / per-arch unit**:
+
+- `remote-build` (expensive, Launchpad) vs `upload` (store macaroon `SNAPCRAFT_STORE_CREDENTIALS`) vs `ensure-track` (storefront cookie `SNAPCRAFT_SESSION_COOKIE`) are independent failure domains with different credentials.
+- Per-arch matrices let one arch fail and recover alone.
+- Setup steps (`checkout`, `install snapcraft`, credentials, `meta`) are *not* isolated further: every job already repeats checkout + `snap install snapcraft` (~30–60 s), so more jobs means more repeated setup. Four functional jobs + `report` is the sweet spot.
+
+## Gating (the load-bearing part)
+
+A matrix counts as **one** job for `needs`: if any leg fails, the matrix job's result is `failure`, and a plain `needs:` dependent is **skipped**. Partial-arch tolerance therefore depends on explicit conditions.
+
+| Job | `if:` | Rationale |
+|---|---|---|
+| `ensure-track` | `${{ github.event_name == 'pull_request' }}` | Independent of builds — runs regardless of any build outcome. |
+| `build` | (default) + `strategy.fail-fast: false` | A dead arch must not cancel its siblings. |
+| `upload` | `${{ !cancelled() && needs.ensure-track.result == 'success' }}` + `fail-fast: false` | Run even though the `build` matrix reports `failure` from a sibling, but **only if the track exists**. |
+| `report` | `${{ always() }}` | Always post the comment + run the fail-gate, even on failure/cancellation. |
+
+Two hard rules that make selective re-run correct:
+
+1. **`upload (arch)` must FAIL when its own `snap-<arch>` artifact is absent** (not silently no-op). Otherwise "Re-run failed jobs" would rebuild the arch but skip its upload, leaving a silent gap.
+2. **`upload` depends on `build`** (for ordering) so a re-run waits for the rebuilt arch's artifact before uploading.
+
+### Re-run truth table
+
+"Re-run failed jobs" reruns only still-failed legs + jobs skipped because of them + `report`; **successful legs are reused** (verified against GitHub matrix semantics).
+
+| First-run failure | What reruns on "Re-run failed jobs" | Reused (not rerun) |
+|---|---|---|
+| `ensure-track` (expired cookie) | `ensure-track`, all `upload` legs (were skipped via the `result=='success'` gate), `report` | all `build` legs → **no rebuild** |
+| one `build (armhf)` | `build-armhf`, `upload-armhf` (failed: artifact missing), `report` | `build-amd64/arm64`, `upload-amd64/arm64` → **no rebuild, no duplicate revisions** |
+| one `upload (armhf)` (transient, survived `retry.sh`) | `upload-armhf`, `report` | all builds + other uploads |
+
+`upload` re-uploading an already-published arch would mint a **new store revision** (`snapcraft upload` always creates one); reusing successful legs is what prevents that churn.
+
+## Data flow
+
+- **Snaps:** `build (arch)` → `actions/upload-artifact` `snap-<arch>` (retention 1 day — throwaway per-PR). `upload (arch)` → `actions/download-artifact` `snap-<arch>`.
+- **Published set:** `upload (arch)` on success → marker artifact `uploaded-<arch>`. `report` globs `uploaded-*` to learn exactly which archs reached the channel. (Matrix job *outputs* are unreliable — last-writer-wins — so artifacts are the source of truth.)
+- **Build-failure log:** the existing snapcraft-log capture moves into `build`; on failure it uploads the log as an artifact for `report` to fold into the comment.
+- **Meta:** `meta` job outputs (`version`, `track`, `archs`) consumed via `needs.meta.outputs.*`.
+
+## `report` comment
+
+The channel is `v<MM>/edge/<PR>`; `snap install` is arch-agnostic (snapd resolves the running arch), so per-arch information is expressed as the **availability list** bound to the command. Three renderings:
+
+**All archs published**
+```
+✅ Published to `v11.21/edge/210` — available to install & test:
+
+  Architectures: amd64, arm64, armhf
+  sudo snap install zwave-js-ui --channel=v11.21/edge/210      # auto-selects your arch
+  # or: sudo snap refresh zwave-js-ui --channel=v11.21/edge/210
+```
+
+**Partial (≥1 arch failed)** — notify, and the command carries the arch list it works on
+```
+⚠️ Partial publish to `v11.21/edge/210` — 2 of 3 architectures.
+
+  Available for: amd64, arm64
+  sudo snap install zwave-js-ui --channel=v11.21/edge/210      # works on: amd64, arm64
+  # or: sudo snap refresh zwave-js-ui --channel=v11.21/edge/210
+
+  ❌ Failed: armhf — use "Re-run failed jobs" to retry just that arch (no rebuild of amd64/arm64).
+```
+
+**None published**
+```
+❌ No architectures were published for this PR. (snapcraft log folded below.)
+```
+
+`Available for` = the `uploaded-<arch>` set. `❌ Failed` = `wanted − published`. The sticky comment keeps the existing `<!-- pr-build-snap -->` marker so it updates in place. The fail-gate (`exit 1` when any wanted arch is unpublished) still reds the check on a partial — the red status is what drives "Re-run failed jobs".
+
+**Event scope:** release (`ensure-track`, `upload`) and the fail-gate apply to `pull_request` events only, matching today's `github.event_name == 'pull_request'` guards. A `workflow_dispatch` run is **build-only** and passes when the builds succeed (nothing is published, so the fail-gate does not red it). `report` still posts a comment only on `pull_request`.
+
+## `release-on-merge.yml` — retry-hardening only
+
+No job split (no expensive build; promotions are idempotent). Wrap each store mutation in the existing helper:
+
+```
+.github/scripts/retry.sh 3 15 -- snapcraft promote  … --yes
+.github/scripts/retry.sh 3 15 -- snapcraft close    …
+.github/scripts/retry.sh 3 15 -- snapcraft set-default-track …
+```
+
+This gives the same transient-401/disconnect resilience the PR upload already has.
+
+## Per-arch build matrix — notes & risk
+
+Splitting `remote-build` per arch means `remote-build.sh <single-arch>` (it already accepts a comma-list; one element is valid) invoked in N parallel jobs instead of one `--build-for=a,b,c` call.
+
+- **Benefit:** independent per-arch retry; wall-clock ≈ slowest single arch instead of the sum.
+- **Risk:** N concurrent Launchpad remote-builds instead of one request. The account has previously hit a Launchpad-side scanner wedge; more concurrent requests could change queueing behavior. Acceptance criterion: the first real PR run must show all archs building in parallel and producing artifacts. If Launchpad concurrency proves problematic, the fallback is a single `build` job that builds all archs and emits per-arch artifacts (keeps the per-arch *upload* benefit, drops per-arch *build* parallelism).
+
+## Testing
+
+This is workflow-YAML restructuring; `remote-build.sh`, `snap-create-track.sh`, `retry.sh`, and `snap-release.sh` are unchanged, so their existing `*.test.sh` continue to apply. Any new bash extracted into a script (e.g. the `report` comment renderer, if pulled out for testability) gets unit tests following the repo pattern. The only true integration test is a real PR run; acceptance:
+
+1. Clean PR: all archs build in parallel, track ensured, all archs upload, comment lists all archs, check green.
+2. Forced release failure (e.g. stale cookie): build succeeds, `ensure-track` fails, uploads skip, comment shows none/partial, check red. Then "Re-run failed jobs" → only `ensure-track` + uploads + report rerun, **no rebuild**, check green.
+3. Forced single-arch build failure: other archs publish; comment notifies + lists available archs; "Re-run failed jobs" rebuilds + uploads only the failed arch; successful archs not re-uploaded (no new revisions).
+
+## Out of scope
+
+- `remote-build.sh` / `snap-release.sh` / `snap-create-track.sh` / `retry.sh` logic changes (used as-is).
+- Any change to which paths trigger the workflow, the per-PR channel scheme, or `release-on-merge`'s promotion logic.
+- Refreshing the `SNAPCRAFT_SESSION_COOKIE` secret (operational; required to unblock #210, independent of this work).


### PR DESCRIPTION
## Summary

Splits the PR build/release CI so a failed **release** retries **without** re-running the ~39-min Launchpad build, and makes each architecture independently buildable, publishable, and re-runnable. Motivated by PR #210, which failed *after* a successful 39-min build at `Ensure version track exists` (HTTP 401 — expired `SNAPCRAFT_SESSION_COOKIE`) and would have forced a full rebuild to retry.

`pr-build-snap.yml` becomes a five-job DAG:

```
        ┌─► ensure-track ─────────────────────────────┐
meta ───┤                                              ├─► report (always)
        └─► build(arch)[matrix] ──► upload(arch)[matrix] ┘
```

- **`build`/`upload` are per-arch matrices** (`fail-fast: false`). Snaps move build→upload as per-arch artifacts; `report` derives the published set from `uploaded-<arch>` marker artifacts.
- **Selective "Re-run failed jobs":** `ensure-track` fails → uploads skip, builds reused (no rebuild); one `build-<arch>` fails → only that arch's build+upload re-run, the others aren't re-uploaded (no duplicate store revisions). `upload-<arch>` **fails** on a missing artifact so re-run re-pairs a rebuilt arch with its upload.
- **`report`** posts a sticky comment listing exactly which archs reached the channel (with the install command bound to the available-arch list), a distinct "release blocked" note when the track couldn't be ensured, and a fail-gate that names the missing archs.
- New pure, unit-tested renderer `.github/scripts/pr-comment.sh` (+ `pr-comment.test.sh`).
- `release-on-merge.yml`: each `snapcraft promote`/`close`/`set-default-track` wrapped in `retry.sh` for transient-401/disconnect resilience.

Design: `docs/superpowers/specs/2026-06-22-ci-build-release-split-design.md` · Plan: `docs/superpowers/plans/2026-06-22-ci-build-release-split.md`

## Test Plan

Local (green): `shellcheck .github/scripts/*.sh` clean; all 5 `*.test.sh` pass (incl. new `pr-comment` 16/16); all workflows parse.

The true integration test is a live run. **Note:** this PR only touches `.github/**` + `docs/**`, so `pr-build-snap.yml`'s path filter (`snap/**`,`src/**`,`requirements-duplicity.txt`) intentionally does **not** trigger it here — only `helper-tests`/`lint-test`/policy run. Exercise the new workflow via:

- [x] `workflow_dispatch` run (build-only path: `meta` + per-arch `build`, no release)
- [x] A PR touching `snap/`/`src/` after refreshing `SNAPCRAFT_SESSION_COOKIE` → all archs build in parallel, track ensured, all upload, comment lists all archs, check green
- [ ] Selective re-run (release): with a stale cookie, builds stay green; **Re-run failed jobs** reruns only `ensure-track`+`upload`+`report` — no rebuild
- [ ] Selective re-run (arch): force one `build-<arch>` to fail; others publish, comment notifies + lists available archs; **Re-run failed jobs** rebuilds+uploads only the failed arch (no new revisions for already-published archs)

**Operational prerequisite (out of scope):** refresh the `SNAPCRAFT_SESSION_COOKIE` repo secret (the #210 blocker) for the release half to go green.
