### PR TITLE
fix(ui): page with less -R, not gum pager (fixes help table wrap)

### DIFF
--- a/src/helper/ui
+++ b/src/helper/ui
@@ -191,11 +191,15 @@ ui_usage() {                   # stdin: usage text (readable raw; light markdown
 }
 
 ui_pager() {                   # stdin: content -> scrollable viewport when it overflows the screen.
-                               # Gates on stdout (ui_ctx), NOT stdin: gum pager reads content from
-                               # stdin and keystrokes from /dev/tty, so the content can be a pipe.
+                               # Pages with `less -R`, NOT `gum pager`: gum pager draws a border +
+                               # line-number gutter that shrink the usable width and re-wrap content
+                               # already sized to the terminal (e.g. the help command table). less is
+                               # full-width, keeps colours (-R), and is staged in the snap. Gates on
+                               # stdout (ui_ctx); content arrives on stdin, less reads keys from /dev/tty.
     local content; content="$(cat)"
-    if [ "$(ui_ctx)" = styled ] && [ "$(printf '%s\n' "$content" | wc -l)" -gt "$(ui_lines)" ]; then
-        printf '%s\n' "$content" | "$UI_GUM" pager
+    if [ "$(ui_ctx)" = styled ] && command -v less >/dev/null 2>&1 \
+       && [ "$(printf '%s\n' "$content" | wc -l)" -gt "$(ui_lines)" ]; then
+        printf '%s\n' "$content" | less -R
     else
         printf '%s\n' "$content"
     fi

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -166,18 +166,20 @@ printf '%s\n' "$_two" | nth_fpr 3 >/dev/null 2>&1; assert_status "$?" "1" "nth_f
 printf '%s\n' "$_two" | nth_fpr x >/dev/null 2>&1; assert_status "$?" "1" "nth_fpr: non-numeric -> 1"
 printf '%s\n' "$_two" | nth_fpr '' >/dev/null 2>&1; assert_status "$?" "1" "nth_fpr: empty -> 1"
 
-# --- status routes through ui_pager (passthrough in plain ctx) -----------------
-# main status on a tiny styled screen must go through the gum pager stub.
-# TERM must be non-dumb: ui_ctx returns plain on TERM=dumb BEFORE the UI_ASSUME_TTY
-# check, and GitHub runners export no TERM (bash defaults it to dumb) — so pin it
-# here, or this styled assertion passes locally but fails in CI.
-sp="$(SNAPCTL_backup_target="sftp://nas/zui" GNUPGHOME="$SNAP_COMMON/.gnupg" \
-     TERM=xterm-256color UI_ASSUME_TTY=1 UI_COLS=999 UI_LINES=2 main status 2>/dev/null)"
-assert_contains "$sp" "[pager]" "main status: pages through ui_pager on a tiny styled screen"
-# plain ctx: no pager, content intact
+# --- status routes through ui_pager (less) on a tiny styled screen --------------
+# ui_pager pages with `less -R` (see helper/ui). Stub less on PATH so it's invoked
+# (and doesn't block). TERM must be non-dumb: ui_ctx returns plain on TERM=dumb
+# BEFORE the UI_ASSUME_TTY check, and GitHub runners export no TERM — so pin it.
+PATH="$HERE/fixtures/bin:$PATH"
+LESS_LOG="$SNAP_DATA/less.log"; export LESS_LOG; : > "$LESS_LOG"
+SNAPCTL_backup_target="sftp://nas/zui" GNUPGHOME="$SNAP_COMMON/.gnupg" \
+     TERM=xterm-256color UI_ASSUME_TTY=1 UI_COLS=999 UI_LINES=2 main status >/dev/null 2>&1
+assert_contains "$(cat "$LESS_LOG")" "-R" "main status: pages via less on a tiny styled screen"
+# plain ctx: no pager, content intact, less NOT invoked
+: > "$LESS_LOG"
 spp="$(SNAPCTL_backup_target="sftp://nas/zui" GNUPGHOME="$SNAP_COMMON/.gnupg" \
       NO_COLOR=1 UI_LINES=2 main status 2>/dev/null)"
 assert_contains "$spp" "sftp://nas/zui" "main status: plain ctx keeps content"
-case "$spp" in *'[pager]'*) FAIL=$((FAIL+1)); echo "FAIL: plain ctx paged status" >&2 ;; *) PASS=$((PASS+1)) ;; esac
+assert_eq "$(cat "$LESS_LOG")" "" "main status: plain ctx -> less NOT invoked"
 
 finish

--- a/tests/fixtures/bin/less
+++ b/tests/fixtures/bin/less
@@ -1,7 +1,13 @@
 #!/usr/bin/env bash
-# Fake less for unit tests: record argv, drain a few lines from the file arg
-# (proves it can read the FIFO), then exit (simulates the user pressing q).
+# Fake less for unit tests: record argv, then consume input so the producer never
+# blocks, then exit (simulates the user quitting). Handles both call shapes:
+#   logs viewer:  less +F -R <fifo>      -> last arg is a file/pipe; drain a few lines
+#   ui_pager:     <content> | less -R    -> no file arg; drain stdin
 [ -n "${LESS_LOG:-}" ] && printf '%s\n' "$*" >> "$LESS_LOG"
 f="${*: -1}"
-n=0; while [ "$n" -lt 3 ] && IFS= read -r _; do n=$((n+1)); done < "$f" 2>/dev/null
+if [ -f "$f" ] || [ -p "$f" ]; then
+    n=0; while [ "$n" -lt 3 ] && IFS= read -r _; do n=$((n+1)); done < "$f" 2>/dev/null
+else
+    cat >/dev/null 2>&1
+fi
 exit 0

--- a/tests/ui_test.sh
+++ b/tests/ui_test.sh
@@ -211,17 +211,23 @@ plain="$(printf 'k\tv\n' | ui_table key value)"
 assert_contains "$plain" "k" "plain: aligned still works"
 printf '%s' "$plain" | grep -q "$(printf '\033')"; assert_status "$?" "1" "plain: zero ANSI"
 
-# --- ui_pager: scroll only when styled AND taller than the screen --------------
+# --- ui_pager: scroll via `less -R` when styled AND taller than the screen ------
+# less, NOT gum pager: gum pager's border + line-number gutter shrink the usable
+# width and re-wrap a table already sized to the terminal (the wrap regression).
+PATH="$HERE/fixtures/bin:$PATH"   # use the less stub, not real less (which would block)
 big="$(seq 1 50)"
-assert_contains "$(printf '%s\n' "$big" | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager)" "[pager]" "pager: styled + overflow -> gum pager"
-# fits -> passthrough (no pager)
+LESS_LOG="$SNAP_DATA/less_pager.log"; export LESS_LOG; : > "$LESS_LOG"
+printf '%s\n' "$big" | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager >/dev/null
+assert_contains "$(cat "$LESS_LOG")" "-R" "pager: styled + overflow -> less -R"
+# fits -> passthrough: content intact, less NOT invoked
+: > "$LESS_LOG"
 fits="$(printf 'a\nb\n' | UI_ASSUME_TTY=1 UI_LINES=10 ui_pager)"
-assert_eq "$fits" "$(printf 'a\nb')" "pager: fits -> passthrough (exact equality also proves no [pager])"
-# plain ctx -> passthrough even when tall
+assert_eq "$fits" "$(printf 'a\nb')" "pager: fits -> passthrough"
+assert_eq "$(cat "$LESS_LOG")" "" "pager: fits -> less NOT invoked"
+# plain ctx -> passthrough even when tall, less NOT invoked
+: > "$LESS_LOG"
 plain="$(printf '%s\n' "$big" | NO_COLOR=1 UI_LINES=10 ui_pager)"
-case "$plain" in *'[pager]'*) FAIL=$((FAIL+1)); echo "FAIL: plain ctx paged" >&2 ;; *) PASS=$((PASS+1)) ;; esac
 assert_contains "$plain" "50" "pager: plain passthrough keeps content"
-# Note: ui_pager gates on stdout (ui_ctx), not stdin — every case above already
-# pipes content in (stdin not a tty), so test 1 covers "piped + styled -> pages".
+assert_eq "$(cat "$LESS_LOG")" "" "pager: plain -> less NOT invoked"
 
 finish


### PR DESCRIPTION
## Symptom
On a normal-width terminal, `zwave-js-ui.help`'s **command table wraps** (border spills to the next line), even though the table fits the terminal.

## Root cause (confirmed, not guessed)
The table is exactly **85 display columns**; a reporting terminal was **93** — it fits. But `help` pipes its output through `ui_pager`, which used **`gum pager`**, and this gum build renders the pager with a **rounded border + a line-number gutter** (~9 columns of chrome), shrinking the content area to ~84. `ui_table` sized the table to the *full* terminal (85 ≤ 93 → renders the table), but `gum pager` then displays it in ~84 cols → re-wraps by ~1.

Confirmed by A/B on the real snap:
- `UI_LINES=9999 zwave-js-ui.help` (pager skipped) → table renders clean, no wrap.
- `zwave-js-ui.help` (paged) → wrapped inside gum pager's border + `│ N │` gutter.

It's a **width-contract mismatch between two `ui_` primitives**: `ui_table` fits to the terminal; `ui_pager` then narrows it.

## Fix
`ui_pager` pages with **`less -R`** instead of `gum pager`: full-width, no border or gutter, preserves colours (`-R`), and **already staged** in the snap (added for the Part B logs viewer — no new dependency). The 85-col table now sits in the full 93 → no wrap. Plain / `NO_COLOR` / `TERM=dumb` / piped paths are unchanged (straight passthrough).

## Tests
`ui_pager` tests now assert it invokes `less -R` (via a PATH `less` stub) on overflow and passes through otherwise; the `backup status` paging test updated likewise; the shared `less` stub now also drains stdin (ui_pager's `content | less -R` shape, in addition to the logs viewer's `less +F -R <fifo>`). 237 assertions across 5 suites, green under both a normal env and `TERM=dumb` (CI parity); shellcheck clean.

Note: this can only be fully *seen* with a real controlling terminal (the failure was invisible to CI/pty harnesses, which lack one) — verifiable post-build via `snap refresh … && zwave-js-ui.help`.
