### PR TITLE
ci(build): bump artifact retention 1→7 days (usable selective-rerun window)

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -100,7 +100,7 @@ jobs:
         with:
           name: snap-${{ matrix.arch }}
           path: ${{ env.SNAP_NAME }}*${{ matrix.arch }}.snap
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
       - name: Capture snapcraft log on failure
         if: ${{ always() && steps.build.outputs.snaps == '0' }}
@@ -121,7 +121,7 @@ jobs:
         with:
           name: buildlog-${{ matrix.arch }}
           path: ${{ env.BUILDLOG }}
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: ignore
           overwrite: true   # "Re-run failed jobs" re-runs this leg; replace the prior attempt's log
 
@@ -173,7 +173,7 @@ jobs:
         with:
           name: uploaded-${{ matrix.arch }}
           path: out/uploaded-${{ matrix.arch }}
-          retention-days: 1
+          retention-days: 7
           if-no-files-found: error
 
   report:


### PR DESCRIPTION
## Summary
Bumps the per-arch artifact retention in `pr-build-snap.yml` from **1 → 7 days** (the `snap-<arch>`, `buildlog-<arch>`, and `uploaded-<arch>` artifacts).

The 1-day window made the headline feature of #217 — fix a release failure (e.g. expired `SNAPCRAFT_SESSION_COOKIE`) and **Re-run failed jobs** reusing the already-built snaps, *no rebuild* — unusable whenever the fix took more than a day. Concretely: the first `v11.21` run's `snap-<arch>` artifacts expired before the cookie was refreshed, so the recovery needed a full ~39-min rebuild anyway. 7 days gives a realistic window to fix-then-rerun without rebuilding.

## Test Plan
- [x] `retention-days: 7` on all three uploads; YAML parses
- [ ] Next build PR: confirm artifacts show a 7-day `expires_at`