### PR TITLE
ci(release): refuse promoting a stale-version branch build

### DIFF
--- a/.github/workflows/release-on-merge.yml
+++ b/.github/workflows/release-on-merge.yml
@@ -71,6 +71,17 @@ jobs:
             exit 0
           fi
 
+          # Guard: the revision sitting in $BRANCH must be the version we just merged.
+          # A PR built on a stale base (snapcraft.yaml behind main) and merged without a
+          # rebuild leaves an OLDER version in its branch channel; promoting that would
+          # push the old build into latest/* and the track's stable, silently regressing
+          # the channels. Refuse, and tell the maintainer how to recover.
+          BRANCH_VER="$("$SR" channel-version "$BRANCH" <<<"$INFO")"
+          if [ "$BRANCH_VER" != "$V" ]; then
+            echo "::error::release-on-merge: ${BRANCH} holds ${BRANCH_VER:-<none>}, but the merged snapcraft.yaml version is ${V}. Refusing to promote a stale/mismatched build — rebase the PR on current main and re-run its build, or release the correct revision manually (snapcraft revisions ${SNAP} -> snapcraft release ${SNAP} <rev> ${TRACK}/stable,latest/candidate,latest/edge)."
+            exit 1
+          fi
+
           CAND="$("$SR" channel-version latest/candidate <<<"$INFO")"
           echo "Merged $V; current latest/candidate=${CAND:-<none>}"
 


### PR DESCRIPTION
## Summary
Adds a version-match guard to `release-on-merge.yml`: before promoting, it asserts the revision sitting in `v<MM>/edge/<PR>` is the **same version** that was just merged (`snapcraft.yaml`). On mismatch it **refuses** (`::error` + `exit 1`) with recovery instructions, instead of silently promoting an older build.

## Why
Live incident (v11.21.1): PR #220 was built from a **stale base** — its `snapcraft.yaml` still said `v11.21.0` (never rebased onto #219's bump). On merge, `release-on-merge` promoted that `v11.21.0` revision into `latest/candidate`, `latest/edge`, **and `v11.21/stable`** — silently regressing every channel over the newer v11.21.1, which was left orphaned.

The promotion logic moved the branch revision forward based on the *merged* `$V` (`v11.21.1`) while the *actual* revision was `v11.21.0`. This guard catches exactly that mismatch.

It reuses the existing, unit-tested `snap-release.sh channel-version` helper (already used by the `branch-has-revisions` guard on the same `$BRANCH`, against `snapcraft status`), so there's no new parsing.

## Test Plan
- [x] YAML parses; `channel-version` helper unchanged (its `*.test.sh` still applies)
- [ ] Next mismatched merge (if any) shows the `::error` and the release-on-merge job goes red instead of regressing channels
- [ ] A normal merge (branch version == merged version) promotes as before

## Note
Complements branch-protection "require branches up to date before merging" (drafted separately), which prevents the stale-base merge in the first place; this guard is the defense-in-depth backstop at promotion time.