### PR TITLE
fix(logs): pass -f to less so it opens the FIFO viewport (fixes broken zwave-js-ui.logs)

### DIFF
--- a/src/bin/logs
+++ b/src/bin/logs
@@ -233,7 +233,9 @@ main() {
 
     # Interactive terminal + a pager: follow live AND let the user scroll back.
     # The producer (followers + wait) backgrounds into a FIFO; less reads the FIFO
-    # in the foreground (keys from /dev/tty) with +F (follow) and -R (keep colours).
+    # in the foreground (keys from /dev/tty) with +F (follow), -R (keep colours),
+    # and -f (a FIFO is a non-regular file; interactive less refuses it otherwise:
+    # "<fifo> is not a regular file (use -f to see it)").
     # Quitting less kills the producer, whose trap reaps the tailers — no orphans.
     # (run_followers always launches >=1 follower with the current stream logic; a
     # zero-follower producer would close the FIFO and leave less at an empty EOF page.)
@@ -242,7 +244,7 @@ main() {
         if ! mkfifo "$fifo" 2>/dev/null; then run_followers; return; fi
         run_followers >"$fifo" &
         local producer=$!
-        less +F -R "$fifo"
+        less +F -R -f "$fifo"
         kill -TERM "$producer" 2>/dev/null
         wait "$producer" 2>/dev/null
         rm -f "$fifo"

--- a/tests/fixtures/bin/less
+++ b/tests/fixtures/bin/less
@@ -1,10 +1,20 @@
 #!/usr/bin/env bash
-# Fake less for unit tests: record argv, then consume input so the producer never
-# blocks, then exit (simulates the user quitting). Handles both call shapes:
-#   logs viewer:  less +F -R <fifo>      -> last arg is a file/pipe; drain a few lines
+# Fake less for unit tests: record argv, mimic the real-less behaviour the callers
+# depend on, then consume input so the producer never blocks, then exit.
+#
+# Real less REFUSES a non-regular file (the log-viewer FIFO) unless -f/--force is
+# given — "<f> is not a regular file (use -f to see it)". Enforce that here so a
+# missing -f fails the test instead of silently passing (the bug this guards). Shapes:
+#   logs viewer:  less +F -R -f <fifo>   -> file arg present; drain a few lines
 #   ui_pager:     <content> | less -R    -> no file arg; drain stdin
 [ -n "${LESS_LOG:-}" ] && printf '%s\n' "$*" >> "$LESS_LOG"
+has_f=0
+for a in "$@"; do case "$a" in -f|--force) has_f=1 ;; --*) ;; -*f*) has_f=1 ;; esac; done
 f="${*: -1}"
+if { [ -p "$f" ] || { [ -e "$f" ] && [ ! -f "$f" ]; }; } && [ "$has_f" -eq 0 ]; then
+    printf '%s is not a regular file (use -f to see it)\n' "$f" >&2
+    exit 1
+fi
 if [ -f "$f" ] || [ -p "$f" ]; then
     n=0; while [ "$n" -lt 3 ] && IFS= read -r _; do n=$((n+1)); done < "$f" 2>/dev/null
 else

--- a/tests/logs_test.sh
+++ b/tests/logs_test.sh
@@ -144,6 +144,13 @@ if command -v script >/dev/null 2>&1; then
             main zui
         ' /dev/null 2>&1; echo "rc=$?")"
     assert_contains "$(cat "$LESS_LOG" 2>/dev/null)" "+F -R" "viewer: TTY run launches less +F -R"
+    # The viewport is a FIFO, which real less refuses without -f ("not a regular
+    # file") — the pager MUST pass -f, or the whole command breaks on a TTY.
+    assert_contains "$(cat "$LESS_LOG" 2>/dev/null)" "-f" "viewer: less gets -f (FIFO is non-regular)"
+    case "$out" in
+        *"is not a regular file"*) FAIL=$((FAIL+1)); echo "FAIL: viewer hit less 'not a regular file' (needs -f on the FIFO)" >&2 ;;
+        *) PASS=$((PASS+1)) ;;
+    esac
     assert_contains "$out" "rc=0" "viewer: paged run exits cleanly (no hang)"
 fi
 


### PR DESCRIPTION
## Symptom (user-reported, rev 975 / v11.21.1)
```
$ sudo zwave-js-ui.logs
/var/snap/zwave-js-ui/common/.zlogs.qUDn3W is not a regular file (use -f to see it)
```
`zwave-js-ui.logs` is broken for **every interactive user** (no-arg, `zui`, `zwjs` all fail). Shipped in the Part B live-log viewer (#213).

## Root cause (reproduced + verified)
The viewer backgrounds the followers into a **FIFO** and reads it with `less +F -R "$fifo"`. **Interactive `less`** (stdout = tty) refuses to open a non-regular file (a FIFO) without `-f`/`--force` — that error string is `less`'s own. Confirmed against real `less` 590 under a controlling tty:

- `less -R <fifo>` (no `-f`) → `rc=1`, `<fifo> is not a regular file (use -f to see it)` ← the user's error
- `less -f +F -R <fifo>` → opens and follows the FIFO, no error

(With stdout piped — as in CI/test harnesses — `less` runs in non-interactive "cat" mode and skips the check, which is why the suite never saw it.)

## Fix
`less +F -R "$fifo"` → **`less +F -R -f "$fifo"`** (one flag).

## Test gap closed
The bug was invisible because the test `less` stub drained any path without enforcing the rule. The stub now **mimics real `less`** — it refuses a non-regular file arg unless `-f` is present. The pty integration test now asserts the viewer passes `-f` and that the run never prints `is not a regular file`. With the faithful stub the suite goes RED without the fix, GREEN with it.

## Verification
- Unit: 240 assertions across 5 suites, green under a normal env **and** `TERM=dumb` (CI parity); shellcheck clean.
- **End-to-end**: ran the actual fixed `src/bin/logs` under `script(1)` with **real `less` + real `tail` + a real FIFO** → no error, real log lines follow through the pager.

Independent of #220 (already merged); touches `src/bin/logs` + the `less` test stub + `tests/logs_test.sh`.
