### PR TITLE
feat(logs): key-legend hint so the scrollable viewer is discoverable

### DIFF
--- a/src/bin/logs
+++ b/src/bin/logs
@@ -14,6 +14,11 @@ Usage: ${SNAP_NAME}.logs [zui|--zui|zwjs|--zwjs]
   zui  | --zui    follow the Z-Wave JS UI application log only
   zwjs | --zwjs   follow the Z-Wave JS driver log only
   -h   | --help   show this help
+
+On an interactive terminal the logs open in a scrollable viewer:
+  Ctrl-C  stop following and scroll back through the whole session
+  F       resume live following
+  q       quit
 EOF
 }
 
@@ -188,6 +193,14 @@ run_followers() {              # launch every resolved follower, reap on exit, t
     wait
 }
 
+log_viewer_hint() {            # legend line leading the paged buffer, so the scroll/follow/quit
+                               # keys are discoverable when the user scrolls to the top (the
+                               # "read the whole session" gesture). Coloured on a TTY; reads
+                               # main's use_color via dynamic scope (like run_followers).
+    local msg='──── live logs · Ctrl-C: scroll back · F: resume follow · q: quit ────'
+    if [ "${use_color:-0}" = 1 ]; then printf '\033[33m%s\033[0m\n' "$msg"; else printf '%s\n' "$msg"; fi
+}
+
 main() {
     # Help works without root and before arg validation. (Only -h/--help; no bare alias.)
     case "${1:-}" in -h|--help) usage; exit 0 ;; esac
@@ -242,7 +255,7 @@ main() {
     if logs_should_page; then
         local fifo; fifo="$(mktemp -u "${SNAP_COMMON:-${TMPDIR:-/tmp}}/.zlogs.XXXXXX")"
         if ! mkfifo "$fifo" 2>/dev/null; then run_followers; return; fi
-        run_followers >"$fifo" &
+        { log_viewer_hint; run_followers; } >"$fifo" &
         local producer=$!
         less +F -R -f "$fifo"
         kill -TERM "$producer" 2>/dev/null

--- a/tests/logs_test.sh
+++ b/tests/logs_test.sh
@@ -162,4 +162,14 @@ printf '%s' '{"gateway":{"logToFile":true},"zwave":{"logToFile":false}}' > "$SNA
   timeout 10 bash -c 'source "$ROOT/src/bin/logs"; require_root() { :; }; main zui' </dev/null >/dev/null 2>&1 )
 assert_eq "$(cat "$LESS_LOG2" 2>/dev/null)" "" "viewer: piped run does NOT invoke less"
 
+# --- viewer hint: a key legend leads the paged buffer (discoverable on scroll-up) ---
+h="$(use_color=1 log_viewer_hint)"
+assert_contains "$h" "Ctrl-C" "hint: documents Ctrl-C (scroll back)"
+assert_contains "$h" "F"      "hint: documents F (resume follow)"
+assert_contains "$h" "q"      "hint: documents q (quit)"
+# coloured on a TTY, plain otherwise
+case "$h" in *$'\033'*) PASS=$((PASS+1)) ;; *) FAIL=$((FAIL+1)); echo "FAIL: TTY hint not coloured" >&2 ;; esac
+hp="$(use_color=0 log_viewer_hint)"
+case "$hp" in *$'\033'*) FAIL=$((FAIL+1)); echo "FAIL: plain hint has ANSI" >&2 ;; *) PASS=$((PASS+1)) ;; esac
+
 finish


### PR DESCRIPTION
Follow-up to #223 (the FIFO `-f` fix, now merged) addressing the discoverability half of the report: *"the log command is not scrollable … must be some way to consult the whole log since the command was exec."*

## Why it felt unscrollable
With #223 the viewer works and **is** scrollable — `less +F` follows live, Ctrl-C drops into scroll mode, and the whole session is buffered (verified: scrolling to the top reaches the first line since launch). But nothing *tells* you that: `less +F` only shows its cryptic native "(interrupt to abort)", and there's no reliable cross-version way to pin a hint (`-Pm` doesn't surface during `+F`; `--header` is absent in some `less` builds, including the snap's staged one).

## Fix
Lead the paged buffer with a **key-legend line**:
```
──── live logs · Ctrl-C: scroll back · F: resume follow · q: quit ────
```
It's the first thing you see when you scroll to the top — exactly the "read the whole session" gesture — and it marks the start of the session. Coloured on a TTY, plain otherwise. Also documented the scroll keys in `zwave-js-ui.logs --help`.

## Verification
- Unit: new `log_viewer_hint` tests (keys present; coloured on TTY, plain otherwise). 244 assertions across 5 suites green under a normal env **and** `TERM=dumb`; shellcheck clean.
- **End-to-end** with real `less`: after Ctrl-C + `g`, both the legend and the start of the session are on screen.

Scoped to `src/bin/logs` + `tests/logs_test.sh`.
