### PR TITLE
fix(ci): retry remote-build with a fresh build, not the no-op --recover

### DIFF
--- a/.github/scripts/remote-build.sh
+++ b/.github/scripts/remote-build.sh
@@ -7,22 +7,27 @@
 # breaks mid-stream ("Connection broken: IncompleteRead"). That leaves a
 # truncated .snap on disk which later fails to unsquash at upload — a passing
 # build turned red by a network blip. We validate every fetched snap, drop any
-# that are truncated/corrupt, and re-fetch via `--recover` (which reuses the
-# existing Launchpad build — NO rebuild) until every requested arch has a VALID
-# snap or the attempts are exhausted.
+# that are truncated/corrupt, and retry with a FRESH `snapcraft remote-build`
+# until every requested arch has a VALID snap or the attempts are exhausted.
+#
+# We do NOT use `--recover`: snapcraft deletes the temporary Launchpad repo after
+# each run, so `--recover` finds nothing ("Could not find repository") and re-
+# fetches nothing — a proven no-op (see PR #213's log). The truncation is
+# intermittent ACROSS runs, so a fresh remote-build is what actually clears it.
+# A retry therefore costs a full rebuild; the default cap is one retry.
 #
 # A genuine single-arch BUILD failure stays tolerated: we keep whatever valid
 # snaps exist and let the caller's completeness gate decide. So this never makes
 # a previously-passing build fail; it only rescues transient download breakage.
 #
 # Usage:  remote-build.sh <comma-separated-archs>        # e.g. amd64,arm64,armhf
-# Env:    MAX_ATTEMPTS (default 3), RETRY_DELAY seconds (default 15)
+# Env:    MAX_ATTEMPTS (default 2 = one retry), RETRY_DELAY seconds (default 15)
 #         GITHUB_OUTPUT (optional) — receives "snaps=<valid-count>"
 # Exit:   0 always (partial-tolerant).
 set -uo pipefail
 
 ARCHS="${1:?usage: remote-build.sh <archs>, e.g. amd64,arm64,armhf}"
-MAX_ATTEMPTS="${MAX_ATTEMPTS:-3}"
+MAX_ATTEMPTS="${MAX_ATTEMPTS:-2}"
 RETRY_DELAY="${RETRY_DELAY:-15}"
 
 IFS=',' read -ra WANT <<< "$ARCHS"
@@ -55,14 +60,10 @@ valid_count() {                # number of *.snap files in the current directory
 attempt=1
 while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
     echo "::group::remote-build attempt ${attempt}/${MAX_ATTEMPTS} (${ARCHS})"
-    # First pass builds + fetches; retries recover the SAME Launchpad build and
-    # only re-download — no rebuild. `|| true`: a partial-arch failure must not
-    # abort, and a transient fetch error is handled by the validate+retry below.
-    if [ "$attempt" -eq 1 ]; then
-        snapcraft remote-build -v --launchpad-accept-public-upload --build-for="$ARCHS" || true
-    else
-        snapcraft remote-build -v --launchpad-accept-public-upload --build-for="$ARCHS" --recover || true
-    fi
+    # A FRESH build every attempt (no `--recover`: it's a no-op — see the header).
+    # `|| true`: a partial-arch failure must not abort, and a transient fetch
+    # error is handled by the validate+retry below.
+    snapcraft remote-build -v --launchpad-accept-public-upload --build-for="$ARCHS" || true
     echo "::endgroup::"
 
     prune_corrupt
@@ -71,7 +72,7 @@ while [ "$attempt" -le "$MAX_ATTEMPTS" ]; do
     [ "$count" -ge "$want" ] && break
 
     if [ "$attempt" -lt "$MAX_ATTEMPTS" ]; then
-        echo "incomplete (${count}/${want}) — re-fetching in ${RETRY_DELAY}s"
+        echo "incomplete (${count}/${want}) — rebuilding in ${RETRY_DELAY}s"
         sleep "$RETRY_DELAY"
     fi
     attempt=$((attempt + 1))

--- a/.github/scripts/remote-build.test.sh
+++ b/.github/scripts/remote-build.test.sh
@@ -1,6 +1,11 @@
 #!/usr/bin/env bash
 # Stub-driven unit tests for remote-build.sh. No network: fake `snapcraft` and
-# `unsquashfs` on PATH simulate a truncated amd64 fetch that recovers on retry.
+# `unsquashfs` on PATH simulate a truncated amd64 fetch.
+#
+# remote-build.sh recovers a truncated FETCH by re-running a FRESH `snapcraft
+# remote-build` — NOT `--recover`, which is a proven no-op (snapcraft deletes the
+# temporary Launchpad repo after each run, so --recover finds nothing to re-fetch).
+# The truncation is intermittent ACROSS runs, so a fresh build clears it.
 set -uo pipefail  # no -e: keep all tests running even if one fails
 
 HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -16,8 +21,11 @@ check() { # desc expected actual
 }
 
 # Build a throwaway workspace with stub snapcraft + unsquashfs on PATH.
-# mode=flaky:   amd64 download truncated on the first fetch, intact once recovered.
-# mode=partial: amd64 never produces an artifact (a genuine build failure).
+# mode=flaky:   amd64 truncated on attempt 1, intact from attempt 2 (a fresh build clears it)
+# mode=always:  amd64 truncated on EVERY attempt (exercises the retry cap)
+# mode=partial: amd64 never produces an artifact (a genuine build failure)
+# Any `--recover` in the snapcraft args is recorded to $work/recover_used so a test
+# can assert the script never uses it.
 setup() { # $1 = mode -> echoes workdir
   local mode="$1" work bin
   work="$(mktemp -d)"; bin="$work/bin"; mkdir -p "$bin"
@@ -31,15 +39,19 @@ EOF
   cat > "$bin/snapcraft" <<EOF
 #!/usr/bin/env bash
 state="$work/attempts"; n=0; [ -f "\$state" ] && n="\$(cat "\$state")"; n=\$((n+1)); echo "\$n" > "\$state"
-recover=0; for a in "\$@"; do [ "\$a" = "--recover" ] && recover=1; done
-printf 'OK' > zwave-js-ui_v1_arm64.snap
-printf 'OK' > zwave-js-ui_v1_armhf.snap
-case "$mode" in
-  flaky)
-    if [ "\$recover" -eq 1 ]; then printf 'OK' > zwave-js-ui_v1_amd64.snap
-    else printf 'CORRUPT' > zwave-js-ui_v1_amd64.snap; exit 1; fi ;;
-  partial)
-    exit 1 ;;
+archs=""
+for a in "\$@"; do
+  [ "\$a" = "--recover" ] && touch "$work/recover_used"
+  case "\$a" in --build-for=*) archs="\${a#--build-for=}" ;; esac
+done
+case ",\$archs," in *,arm64,*) printf 'OK' > zwave-js-ui_v1_arm64.snap ;; esac
+case ",\$archs," in *,armhf,*) printf 'OK' > zwave-js-ui_v1_armhf.snap ;; esac
+case ",\$archs," in *,amd64,*)
+  case "$mode" in
+    flaky)   if [ "\$n" -le 1 ]; then printf 'CORRUPT' > zwave-js-ui_v1_amd64.snap; exit 1; else printf 'OK' > zwave-js-ui_v1_amd64.snap; fi ;;
+    always)  printf 'CORRUPT' > zwave-js-ui_v1_amd64.snap; exit 1 ;;
+    partial) exit 1 ;;
+  esac ;;
 esac
 EOF
   chmod +x "$bin/unsquashfs" "$bin/snapcraft"
@@ -47,29 +59,44 @@ EOF
 }
 
 snaps_line() { printf '%s\n' "$1" | grep -oE 'snaps=[0-9]+' | tail -1; }
+recover_used() { [ -e "$1/recover_used" ] && echo yes || echo no; }
 
-# --- flaky download: retries via --recover, ends with all 3 valid, none corrupt ---
+# --- flaky fetch: a fresh rebuild recovers it; 3 valid, retried ONCE, no --recover ---
 work="$(setup flaky)"
-out="$( cd "$work" && PATH="$work/bin:$PATH" MAX_ATTEMPTS=3 RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf )"
-check "flaky: reports 3 valid snaps"   "snaps=3" "$(snaps_line "$out")"
-check "flaky: 3 snap files on disk"    "3"       "$(find "$work" -maxdepth 1 -name '*.snap' | wc -l | tr -d ' ')"
-check "flaky: no corrupt file remains" "0"       "$(grep -l CORRUPT "$work"/*.snap 2>/dev/null | wc -l | tr -d ' ')"
-check "flaky: retried once (2 builds)" "2"       "$(cat "$work/attempts")"
+out="$( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf )"
+check "flaky: reports 3 valid snaps"    "snaps=3" "$(snaps_line "$out")"
+check "flaky: 3 snap files on disk"     "3"       "$(find "$work" -maxdepth 1 -name '*.snap' | wc -l | tr -d ' ')"
+check "flaky: no corrupt file remains"  "0"       "$(grep -l CORRUPT "$work"/*.snap 2>/dev/null | wc -l | tr -d ' ')"
+check "flaky: retried once (2 builds)"  "2"       "$(cat "$work/attempts")"
+check "flaky: never used --recover"     "no"      "$(recover_used "$work")"
+rm -rf "$work"
+
+# --- single arch (the matrix's real call shape): same fresh-rebuild recovery ---
+work="$(setup flaky)"
+out="$( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 bash "$RB" amd64 )"
+check "single: reports 1 valid snap"    "snaps=1" "$(snaps_line "$out")"
+check "single: retried once (2 builds)" "2"       "$(cat "$work/attempts")"
+rm -rf "$work"
+
+# --- perpetual truncation: retry is CAPPED at the default (2 attempts), then yields ---
+work="$(setup always)"
+out="$( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf )"
+check "always: reports 2 valid snaps"   "snaps=2" "$(snaps_line "$out")"
+check "always: capped at 2 attempts"    "2"       "$(cat "$work/attempts")"
 rm -rf "$work"
 
 # --- genuine partial failure: tolerated, returns the 2 that built, exit 0 ---
 work="$(setup partial)"
-out="$( cd "$work" && PATH="$work/bin:$PATH" MAX_ATTEMPTS=3 RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf )"
-check "partial: reports 2 valid snaps" "snaps=2" "$(snaps_line "$out")"
-check "partial: exhausts 3 attempts"   "3"       "$(cat "$work/attempts")"
-( cd "$work" && PATH="$work/bin:$PATH" MAX_ATTEMPTS=3 RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf ) >/dev/null 2>&1
-check "partial: exit 0 (tolerant)"     "0"       "$?"
+out="$( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf )"
+check "partial: reports 2 valid snaps"  "snaps=2" "$(snaps_line "$out")"
+( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 bash "$RB" amd64,arm64,armhf ) >/dev/null 2>&1
+check "partial: exit 0 (tolerant)"      "0"       "$?"
 rm -rf "$work"
 
 # --- GITHUB_OUTPUT receives the count ---
 work="$(setup flaky)"; gho="$work/gho"
-( cd "$work" && PATH="$work/bin:$PATH" MAX_ATTEMPTS=3 RETRY_DELAY=0 GITHUB_OUTPUT="$gho" bash "$RB" amd64,arm64,armhf ) >/dev/null 2>&1
-check "writes snaps= to GITHUB_OUTPUT" "snaps=3" "$(grep -oE 'snaps=[0-9]+' "$gho" | tail -1)"
+( cd "$work" && PATH="$work/bin:$PATH" RETRY_DELAY=0 GITHUB_OUTPUT="$gho" bash "$RB" amd64,arm64,armhf ) >/dev/null 2>&1
+check "writes snaps= to GITHUB_OUTPUT"  "snaps=3" "$(grep -oE 'snaps=[0-9]+' "$gho" | tail -1)"
 rm -rf "$work"
 
 [ "$fail" -eq 0 ] && echo "All remote-build tests passed." || echo "Some remote-build tests FAILED."


### PR DESCRIPTION
## Problem
`remote-build.sh` recovered a truncated artifact fetch with `snapcraft remote-build --recover`. That's a **proven no-op**: snapcraft deletes the temporary Launchpad git repo after each run, so `--recover` reports `Could not find repository …` and re-fetches nothing (confirmed in PR #213's log — `2/3` valid across all 3 attempts, a single `IncompleteRead`). **The retry has never rescued a failure**; it just burned ~30s + two dead `snapcraft` calls per truncation, then reported `snaps=0`. The test stub gave false confidence by modelling `--recover` as re-creating the file.

## Fix (no manual steps — recovery stays in-CI)
The truncation is intermittent **across runs**, so retry with a **fresh `snapcraft remote-build`** (no `--recover`), which actually clears it. Since a retry now costs a full rebuild, the cap drops to **one retry** (`MAX_ATTEMPTS` 3 → 2).

- Removes the dead `--recover` path.
- Test rewritten to reflect reality: stub models a fresh build clearing the truncation, **respects `--build-for`** (the per-arch matrix call shape), **asserts `--recover` is never used**, and covers the **retry cap** and single-arch path. Genuine partial failures stay tolerated (exit 0, publish what built).

This keeps the original goal — a network blip never turns a green build red — without the `--recover` illusion and without a manual "re-run failed jobs" click.

Scoped to `.github/scripts/` (no snap build triggered).
