### PR TITLE
ci(build): prefer IPv4 for the Launchpad artifact fetch (fixes amd64 Errno 101)

### DIFF
--- a/.github/workflows/pr-build-snap.yml
+++ b/.github/workflows/pr-build-snap.yml
@@ -127,6 +127,14 @@ jobs:
           set -euo pipefail
           mkdir -p ~/.local/share/snapcraft
           printf '%s\n' "${{ secrets.LAUNCHPAD_CREDENTIALS }}" > ~/.local/share/snapcraft/launchpad-credentials
+      # GitHub runners have no working IPv6 route, but launchpad.net publishes AAAA
+      # records — so snapcraft's artifact download intermittently dies with
+      # "[Errno 101] Network is unreachable" when a fetch resolves IPv6 first (seen
+      # 6x consecutively on amd64 in PR #228, while arm64/armhf fetched the same host
+      # over IPv4 fine). snapcraft is a classic snap, so it honours the host's
+      # /etc/gai.conf; prefer IPv4 to force the reachable address.
+      - name: Prefer IPv4 for the Launchpad fetch
+        run: echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
       - name: Remote-build ${{ matrix.arch }}
         id: build
         run: .github/scripts/remote-build.sh "${{ matrix.arch }}"


### PR DESCRIPTION
## Symptom
`build-publish (amd64)` on #228 failed **6 times** (3 runs × 2 attempts), every one:
```
snapcraft internal error: ConnectionError(... launchpad.net:443 ...
  Failed to establish a new connection: [Errno 101] Network is unreachable)
valid snaps after attempt 1: 0/1
```
Each time the **Launchpad build succeeded** ("Succeeded: amd64") — only the artifact **download** failed. **arm64 + armhf fetched the same `launchpad.net` host fine** (over IPv4), and `lint-test` passes, so it's not the recipe.

## Root cause
`launchpad.net` publishes **both** IPv4 (`185.125.189.222/223`) and IPv6 (`2620:2d:4000:1009::…`). GitHub-hosted runners have **no working IPv6 route**, and snapcraft's downloader (urllib3) tries resolved addresses in order without reliable IPv4 fallback — so a fetch that gets the IPv6 address first dies at connect with `ENETUNREACH`. Intermittent by address ordering (why other arches/repos dodge it), but amd64 here hit it every time.

## Fix
snapcraft is installed `--classic` (no confinement → reads the host's `/etc/gai.conf`). Add a precedence rule that sorts IPv4-mapped addresses first, so `getaddrinfo` hands snapcraft the **reachable IPv4** address first:
```
echo 'precedence ::ffff:0:0/96 100' | sudo tee -a /etc/gai.conf
```
One step in the `build-publish` job, before `Remote-build`. Forces the fetch onto IPv4 (proven reachable by arm64/armhf); helps every arch. Complements #226 (IncompleteRead-truncation retry) — together they close both Launchpad-fetch failure modes.

## Validation
Can't be exercised on this `.github`-only PR (paths filter), so verification is on the next build PR: after merge, **rebase #228** — its amd64 build-publish should fetch over IPv4 and go green. If amd64 *still* `Errno 101`s with IPv4 forced, the cause is elsewhere and I'll dig further.
