### PR TITLE
fix(snap): bind /usr/share/iproute2 (stop AppArmor denial spam from bundled ip)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -87,7 +87,7 @@ All bin commands render through `src/helper/ui` (uniform headers/tables/status l
 
 ### Paths & layout
 
-`STORE_DIR=$SNAP_DATA`, external config at `$SNAP_DATA/.ext-config`. The npm cache is redirected via a `layout:` bind to `$SNAP/.cache/npm` to keep it out of the writable store dir. The `store-dir` content slot exposes `$SNAP_DATA` for the optional `code-server` integration.
+`STORE_DIR=$SNAP_DATA`, external config at `$SNAP_DATA/.ext-config`. The npm cache is redirected via a `layout:` bind to `$SNAP/.cache/npm` to keep it out of the writable store dir; a second `layout:` bind maps `/usr/share/iproute2` to the staged copy so the bundled `ip` (compiled-in host path) doesn't spam AppArmor denials into the journal. The `store-dir` content slot exposes `$SNAP_DATA` for the optional `code-server` integration.
 
 ## CI / contribution rules
 

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -142,6 +142,11 @@ layout:
   # Cache is set to (env) something outside the rw mount, to prevent storing it inside the store dir.
   /usr/local/share/.cache/npm:
     bind: $SNAP/.cache/npm
+  # The staged `ip` (dependencies part) has /usr/share/iproute2 compiled in and falls
+  # back to the host path, which strict confinement denies — ~12 AppArmor journal
+  # entries/min while the app polls `ip -o link show`. Bind it to the staged copy.
+  /usr/share/iproute2:
+    bind: $SNAP/usr/share/iproute2
   #/usr/local/share/.yarn: ?? Do we need this? Leave until proper testing is OK
     #symlink: $SNAP/lib/node_modules
 


### PR DESCRIPTION
## Problem

The snap's bundled `ip` (staged via the `dependencies` part's `iproute2` stage-package) is run periodically by the upstream app (`ip -o link show`). On core26/resolute, iproute2 ships its data files in `/usr/share/iproute2` (noble used `/etc/iproute2`), and that path is compiled into the binary — so `ip` reads the **host's** `/usr/share/iproute2/group`, which strict confinement denies.

Observed on-device (lav918, 2026-07-12): **~12 `apparmor="DENIED"` journal entries/min, 3,527 over a 5 h boot**. Functionally harmless — Z-Wave is unaffected — but it floods the journal and wears the SD card.

## Fix

The data files are already inside the snap (resolute's `iproute2` deb ships `/usr/share/iproute2/*` and the part has no stage exclusions), so the whole fix is one `layout:` bind:

```yaml
/usr/share/iproute2:
  bind: $SNAP/usr/share/iproute2
```

Also documents the second layout bind in CLAUDE.md's "Paths & layout" section.

## Verification

- `yq '.layout'` parses cleanly; CI's Launchpad remote-build exercises the full snapcraft build.
- On-device after refreshing to this PR's channel: `journalctl -b | grep 'apparmor="DENIED"' | grep zwave` should go quiet (previously ~12/min).