### PR TITLE
chore(snap): bump Node to 22.23.1 LTS + Renovate-track the 22.x line

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -24,9 +24,36 @@
         "# renovate: depName=(?<depName>[^\\s]+)\\n\\s+source-tag: (?<currentValue>v[\\d.]+)"
       ],
       "datasourceTemplate": "github-releases"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": [
+        "/^snap/snapcraft\\.yaml$/"
+      ],
+      "matchStrings": [
+        "npm-node-version: (?<currentValue>[\\d.]+)"
+      ],
+      "depNameTemplate": "node",
+      "datasourceTemplate": "node-version"
     }
   ],
   "packageRules": [
+    {
+      "matchDatasources": [
+        "node-version"
+      ],
+      "matchPackageNames": [
+        "node"
+      ],
+      "allowedVersions": "<23",
+      "commitMessageTopic": "Node.js",
+      "labels": [
+        "dependencies"
+      ],
+      "prBodyNotes": [
+        "Stays on the Node 22 LTS line: 22.x is the newest line with an official linux-armv7l build (needed by the armhf snap). Node 24+ dropped 32-bit ARM, so the `allowedVersions: <23` ceiling prevents an armhf-breaking major bump. Revisit at Node 22 EOL (2027-04-30)."
+      ]
+    },
     {
       "matchPackageNames": [
         "zwave-js/zwave-js-ui"

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -166,7 +166,12 @@ parts:
       - yq
     plugin: npm
     npm-include-node: true
-    npm-node-version: 22.20.0
+    # Latest Node 22 LTS. Stay on 22.x: it is the newest line that still ships an
+    # official linux-armv7l build, which the armhf snap downloads here. Node 24+
+    # dropped 32-bit ARM, so bumping the major silently breaks the armhf build.
+    # Renovate tracks 22.x security releases (allowedVersions "<23" in renovate.json).
+    # Revisit when Node 22 reaches EOL (2027-04-30): either drop armhf or move the line.
+    npm-node-version: 22.23.1
     source: src/node
     override-build: | # shell
       ZUIV="${SNAPCRAFT_PROJECT_VERSION#v}" yq -i '.version=env(ZUIV),.dependencies.zwave-js-ui=env(ZUIV)' -o=j "${CRAFT_PART_BUILD}/package.json"


### PR DESCRIPTION
Closes the audit's one High finding: the Node runtime was stale **and** unmanaged.

## The problem

`npm-node-version` was pinned at `22.20.0` (2025-09) — three 22.x security releases behind. Root cause: `renovate.json` tracks the `zwave-js-ui` version and gum's `source-tag`, but had **no manager for `npm-node-version`**, so Node was the one dependency nothing ever bumped automatically.

## Why not "just go to the newest Node"

The snap builds **armhf** (32-bit ARM, for 32-bit Raspberry Pi OS), and snapcraft's npm plugin downloads the official Node binary **per arch** — armhf needs `linux-armv7l`. Verified against `nodejs.org/dist/index.json`:

| Node line | Newest | `linux-armv7l`? | Satisfies `engines: node >=20.19`? |
|---|---|---|---|
| 22.x (LTS "Jod") | **22.23.1** | ✅ yes | ✅ |
| 24.x (LTS "Krypton") | 24.18.0 | ❌ **dropped** | ✅ |
| 26.x | 26.5.0 (not LTS) | ❌ | ✅ |

Node 24 dropped 32-bit ARM, so bumping the major would silently break the armhf build. 22.x is the newest line that still works everywhere.

## Change

- **`npm-node-version: 22.20.0 → 22.23.1`** (latest Node 22 LTS).
- **Renovate node-version customManager** for `npm-node-version`, ceilinged at **`allowedVersions: "<23"`** — 22.x security releases now open PRs automatically, but an armhf-breaking major never will.
- Explanatory comment in `snapcraft.yaml` so the 22.x ceiling isn't a mystery to future maintainers.

Node 22 gets security support until **2027-04-30**; the comment + PR-note flag that as the point to revisit (move the line, or drop armhf and go to 24 LTS).

## Verification

- `renovate.json` valid JSON; `snapcraft.yaml` parses (`yq` → `22.23.1`).
- The new manager regex captures `22.23.1` from the bumped line (tested).
- CI's Launchpad remote-build exercises the real per-arch Node download, including armhf.