### PR TITLE
fix(security): %q-escape config in the eval'd duplicity command; redact secrets from hook logs

### DIFF
--- a/src/bin/backup
+++ b/src/bin/backup
@@ -369,7 +369,8 @@ cfg() { snapctl get "backup.$1" 2>/dev/null; }    # $1 = key suffix, e.g. target
 encryption_args() {            # echoes "--encrypt-key X" or "--no-encryption"; status 2 if neither
     local key; key=$(cfg encrypt-key)
     if [ -n "$key" ]; then
-        echo "--encrypt-key $key"
+        # %q: the value is user-set config interpolated into an eval'd command string
+        printf -- '--encrypt-key %q' "$key"
     elif [ "$(cfg encrypt)" = false ]; then
         echo "--no-encryption"
     else
@@ -414,7 +415,7 @@ build_backup_cmd() {           # $1 source dir -> duplicity backup command strin
     # snap revision (e.g. .../x4/backups). snapd copies it forward on refresh, so the
     # path changes between revisions for the SAME logical backup; without this flag
     # duplicity aborts with "Backup source directory has changed" after every refresh.
-    printf '%q -m duplicity backup %s --allow-source-mismatch --full-if-older-than %s --archive-dir %q %q %q' \
+    printf '%q -m duplicity backup %s --allow-source-mismatch --full-if-older-than %q --archive-dir %q %q %q' \
         "$DUP_PY" "$(encryption_args)" "$(full_if_older)" "$ARCHIVE_DIR" "$1" "$(cfg target)"
 }
 

--- a/src/helper/functions
+++ b/src/helper/functions
@@ -63,10 +63,14 @@ function require_root {
 }
 
 function testnset_config {
-    lprint "Testing ${1}, or setting ${2}"
+    # Hooks run with DAEMONIZED=1, so these lprints land in syslog — never log
+    # secret values (session.secret would end up world-readable in the journal).
+    local shown="${2}"
+    case "${1}" in *secret*) shown="(redacted)" ;; esac
+    lprint "Testing ${1}, or setting ${shown}"
     RES=$(snapctl get ${1})
     if [ $? -ne 0 ] || [ -z "${RES}" ]; then
-        lprint "Setting ${1}=${2}"
+        lprint "Setting ${1}=${shown}"
         RES=$(snapctl set ${1}=${2})
         if [ $? -ne 0 ]; then
             lprint "${RES}"

--- a/tests/backup_test.sh
+++ b/tests/backup_test.sh
@@ -36,6 +36,8 @@ assert_eq "$(parse_sub 'import-key')" "import-key" "import-key"
 parse_sub bogus >/dev/null 2>&1; assert_status "$?" "2" "unknown -> 2"
 
 assert_eq "$(SNAPCTL_backup_encrypt_key=ABC123 encryption_args)" "--encrypt-key ABC123" "enc key"
+assert_eq "$(SNAPCTL_backup_encrypt_key='KEY;touch /tmp/pwn' encryption_args)" \
+    "--encrypt-key $(printf '%q' 'KEY;touch /tmp/pwn')" "enc key %q-escaped (hostile value)"
 assert_eq "$(SNAPCTL_backup_encrypt=false encryption_args)"      "--no-encryption"       "no-encryption opt-out"
 encryption_args >/dev/null 2>&1; assert_status "$?" "2" "neither set -> refuse"
 assert_eq "$(SNAPCTL_backup_target=file:///b cfg target)" "file:///b" "cfg reads target"
@@ -57,6 +59,8 @@ assert_contains "$l" "$(printf '%q' "$SNAP/usr/bin/python3") -m duplicity collec
 # shellcheck disable=SC2034  # DUP_PY is consumed inside build_backup_cmd (sourced)
 hb="$( (DUP_PY='/tmp/evil path/python3'; SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt build_backup_cmd "$src") )"
 assert_contains "$hb" "/tmp/evil\\ path/python3 -m duplicity backup " "backup: interpreter %q-escaped (hostile path)"
+hf="$(SNAPCTL_backup_encrypt_key=KEY SNAPCTL_backup_target=file:///tgt SNAPCTL_backup_full_if_older_than='7D;id' build_backup_cmd "$src")"
+assert_contains "$hf" "--full-if-older-than $(printf '%q' '7D;id')" "backup: full-if-older %q-escaped (hostile value)"
 
 rm -rf "$SNAP_DATA/backups"
 has_backups; assert_status "$?" "1" "absent dir -> no backups"

--- a/tests/functions_test.sh
+++ b/tests/functions_test.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Unit tests for src/helper/functions (the shared bash library sourced by every
+# hook and bin script). Same harness as the other suites: stub snapctl, source
+# the real library, assert on rendered output.
+set -u
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+ROOT="$(cd "$HERE/.." && pwd)"
+source "$HERE/lib/assert.sh"
+
+export SNAP="$HERE/fixtures"
+export SNAP_NAME="zwave-js-ui"
+
+# snapctl stub: `get` always misses so testnset_config takes its `set` branch;
+# `set` succeeds silently.
+snapctl() { case "$1" in get) return 1 ;; *) : ;; esac; }
+
+# shellcheck source=/dev/null
+source "$ROOT/src/helper/functions"
+
+# --- testnset_config: hooks run DAEMONIZED, so its lprints land in syslog.
+# Secret values must be redacted there; everything else stays verbatim.
+
+out="$(testnset_config "session.secret" "SUPERSECRET")"
+assert_contains     "$out" "session.secret=(redacted)" "secret: value redacted in log line"
+assert_not_contains "$out" "SUPERSECRET"               "secret: raw value absent from log output"
+
+out="$(testnset_config "server.port" "8091")"
+assert_contains "$out" "Setting server.port=8091" "non-secret: value logged verbatim"
+
+finish

--- a/tests/lib/assert.sh
+++ b/tests/lib/assert.sh
@@ -10,6 +10,10 @@ assert_contains() { # $1 haystack $2 needle $3 msg
     case "$1" in *"$2"*) PASS=$((PASS+1));;
         *) FAIL=$((FAIL+1)); printf 'FAIL: %s\n  %q does not contain %q\n' "$3" "$1" "$2" >&2;; esac
 }
+assert_not_contains() { # $1 haystack $2 needle $3 msg
+    case "$1" in *"$2"*) FAIL=$((FAIL+1)); printf 'FAIL: %s\n  %q unexpectedly contains %q\n' "$3" "$1" "$2" >&2;;
+        *) PASS=$((PASS+1));; esac
+}
 assert_status() { # $1 actual_status $2 expected_status $3 msg
     if [ "$1" = "$2" ]; then PASS=$((PASS+1));
     else FAIL=$((FAIL+1)); printf 'FAIL: %s\n  expected status %s, got %s\n' "$3" "$2" "$1" >&2; fi


### PR DESCRIPTION
Applies the remaining verified findings from the July security audit (SEC-2/3/4). The fourth finding, SEC-1 (stale/unmanaged Node runtime), was resolved separately by #232.

## SEC-2 / SEC-3 — unescaped config in an eval'd root command (`src/bin/backup`)

`build_backup_cmd` renders a duplicity command *string* that is later `eval`'d as root. Two interpolated values were not `%q`-escaped like the rest:

- `encryption_args` echoed `backup.encrypt-key` verbatim
- `backup.full-if-older-than` was formatted with `%s`

A value containing shell metacharacters would be word-split and executed. Both now go through `printf %q`. Setting these keys already requires root (`snap set`), so this is defense-in-depth rather than a privilege boundary — but command builders should be hostile-input-safe regardless.

## SEC-4 — session secret logged to syslog (`src/helper/functions`)

Hooks run with `DAEMONIZED=1`, so `testnset_config`'s `lprint`s route to syslog. On every install/refresh the generated `session.secret` (the cookie-signing secret) landed in the journal in plain text. Keys matching `*secret*` now log `(redacted)`; the real value still reaches `snapctl set`.

## Tests

- `backup_test.sh`: hostile-value cases for `encryption_args` and `--full-if-older-than` (mirrors the existing hostile-`DUP_PY` case).
- New `functions_test.sh`: covers the shared helper library with the same stub-`snapctl` harness; asserts the secret is redacted and non-secret values stay verbatim. `assert_not_contains` added to `tests/lib/assert.sh`.
- Full suite: 294 passed, 0 failed; shellcheck (warning, `-x`) clean.